### PR TITLE
enable custom go linter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,14 @@ jobs:
       - name: Build all lint dependencies
         run: make -j build-node-deps
 
-      # - name: Lint
-      #   uses: golangci/golangci-lint-action@v3
-      #   with:
-      #     version: latest
-      #     skip-pkg-cache: true
-      # - name: Custom Lint
-      #   run: |
-      #     go run ./linters ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-pkg-cache: true
+      - name: Custom Lint
+        run: |
+          go run ./linters ./...
 
       - name: Set environment variables
         run: |

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -109,11 +109,11 @@ type BatchPoster struct {
 	dapWriter          daprovider.Writer
 	// This deviates from the DA spec but is necessary for the batch poster to work efficiently
 	// since we need to an extended method on the SequencerInbox contract
-	eigenDAWriter      eigenda.EigenDAWriter
-	dataPoster         *dataposter.DataPoster
-	redisLock          *redislock.Simple
-	messagesPerBatch   *arbmath.MovingAverage[uint64]
-	non4844BatchCount  int // Count of consecutive non-4844 batches posted
+	eigenDAWriter     eigenda.EigenDAWriter
+	dataPoster        *dataposter.DataPoster
+	redisLock         *redislock.Simple
+	messagesPerBatch  *arbmath.MovingAverage[uint64]
+	non4844BatchCount int // Count of consecutive non-4844 batches posted
 	// This is an atomic variable that should only be accessed atomically.
 	// An estimate of the number of batches we want to post but haven't yet.
 	// This doesn't include batches which we don't want to post yet due to the L1 bounds.
@@ -238,7 +238,7 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	Enable:                             false,
 	DisableDapFallbackStoreDataOnChain: false,
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
-	MaxSize: 100000,
+	MaxSize:             100000,
 	MaxEigenDABatchSize: 2_000_000,
 	// Try to fill 3 blobs per batch
 	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
@@ -274,7 +274,7 @@ var TestBatchPosterConfig = BatchPosterConfig{
 	Enable:                         true,
 	MaxSize:                        100000,
 	Max4844BatchSize:               DefaultBatchPosterConfig.Max4844BatchSize,
-	MaxEigenDABatchSize: 		  DefaultBatchPosterConfig.MaxEigenDABatchSize,
+	MaxEigenDABatchSize:            DefaultBatchPosterConfig.MaxEigenDABatchSize,
 	PollInterval:                   time.Millisecond * 10,
 	ErrorDelay:                     time.Millisecond * 10,
 	MaxDelay:                       0,
@@ -298,7 +298,7 @@ var EigenDABatchPosterConfig = BatchPosterConfig{
 	Enable:                         true,
 	MaxSize:                        100000,
 	Max4844BatchSize:               DefaultBatchPosterConfig.Max4844BatchSize,
-	MaxEigenDABatchSize: 		  DefaultBatchPosterConfig.MaxEigenDABatchSize,
+	MaxEigenDABatchSize:            DefaultBatchPosterConfig.MaxEigenDABatchSize,
 	PollInterval:                   time.Millisecond * 10,
 	ErrorDelay:                     time.Millisecond * 10,
 	MaxDelay:                       0,
@@ -710,7 +710,7 @@ type buildingBatch struct {
 	msgCount          arbutil.MessageIndex
 	haveUsefulMessage bool
 	use4844           bool
-	useEigenDA 	  bool
+	useEigenDA        bool
 }
 
 func newBatchSegments(firstDelayed uint64, config *BatchPosterConfig, backlog uint64, use4844 bool, useEigenDA bool) *batchSegments {

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -553,7 +553,7 @@ func createNodeImpl(
 		return nil, errors.New("a data availability service is required for this chain, but it was not configured")
 	} else if config.EigenDA.Enable {
 		log.Info("EigenDA enabled")
-		eigenDAService, err := eigenda.NewEigenDA(config.EigenDA.Rpc)
+		eigenDAService, err := eigenda.NewEigenDA(&config.EigenDA)
 		if err != nil {
 			return nil, err
 		}
@@ -702,7 +702,7 @@ func createNodeImpl(
 		if daWriter != nil {
 			dapWriter = daprovider.NewWriterForDAS(daWriter)
 		}
-		
+
 		batchPoster, err = NewBatchPoster(ctx, &BatchPosterOpts{
 			DataPosterDB:  rawdb.NewTable(arbDb, storage.BatchPosterPrefix),
 			L1Reader:      l1Reader,

--- a/arbnode/sequencer_inbox.go
+++ b/arbnode/sequencer_inbox.go
@@ -175,8 +175,8 @@ func (m *SequencerInboxBatch) getSequencerData(ctx context.Context, client arbut
 
 		calldata := tx.Data()
 		data := []byte{daprovider.EigenDAMessageHeaderFlag}
-		data = append(data, calldata[:]...)
-		
+		data = append(data, calldata...)
+
 		return data, nil
 	default:
 		return nil, fmt.Errorf("batch has invalid data location %v", m.dataLocation)

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -605,8 +605,8 @@ func mainImpl() int {
 
 	// NOTE: since the SRS is stored within the arbitrator and predetermines the max batch size
 	// supported for proving stateless execution - it could be possible to read from dynamically
-	// otherwise it maybe best to expose the max supported batch size from the disperser directly 
-	// to ensure dynamically adaptability within the rollup. 
+	// otherwise it maybe best to expose the max supported batch size from the disperser directly
+	// to ensure dynamically adaptability within the rollup.
 	if nodeConfig.Node.BatchPoster.Enable && nodeConfig.Node.EigenDA.Enable {
 		if nodeConfig.Node.BatchPoster.MaxEigenDABatchSize > eigenda.MaxBatchSize {
 			log.Error("batchPoster's MaxEigenDABatchSize too large.", "MaxEigenDABatchSize", eigenda.MaxBatchSize)

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -124,6 +124,7 @@ func (dasReader *PreimageDASReader) ExpirationPolicy(ctx context.Context) (dapro
 }
 
 type BlobPreimageReader struct{}
+
 func (r *BlobPreimageReader) GetBlobs(
 	ctx context.Context,
 	batchBlockHash common.Hash,
@@ -149,8 +150,8 @@ func (r *BlobPreimageReader) Initialize(ctx context.Context) error {
 	return nil
 }
 
-
 type EigenDAPreimageReader struct{}
+
 // QueryBlob returns the blob for the given cert from the preimage oracle using the hash of the
 // certificate kzg commitment for identifying the preimage.
 func (dasReader *EigenDAPreimageReader) QueryBlob(ctx context.Context, cert *eigenda.EigenDABlobInfo, domain string) ([]byte, error) {
@@ -177,11 +178,9 @@ func (dasReader *EigenDAPreimageReader) QueryBlob(ctx context.Context, cert *eig
 		println("Error decoding blob: ", err)
 		return nil, err
 	}
-	
+
 	return decodedBlob, nil
 }
-
-
 
 // To generate:
 // key, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000001")

--- a/eigenda/decoding.go
+++ b/eigenda/decoding.go
@@ -93,7 +93,6 @@ func DecodeBlob(data []byte) ([]byte, error) {
 
 }
 
-
 func EncodeBlob(data []byte) ([]byte, error) {
 	var err error
 	data, err = encodeBlob(data)
@@ -103,8 +102,6 @@ func EncodeBlob(data []byte) ([]byte, error) {
 
 	return IFFT(data)
 }
-
-
 
 func encodeBlob(rawData []byte) ([]byte, error) {
 	codecBlobHeader := make([]byte, 32)
@@ -118,12 +115,12 @@ func encodeBlob(rawData []byte) ([]byte, error) {
 	// encode raw data modulo bn254
 	rawDataPadded := codec.ConvertByPaddingEmptyByte(rawData)
 
-	// append raw data
-	encodedData := append(codecBlobHeader, rawDataPadded...)
+	// append raw data; reassgin avoids copying
+	encodedData := codecBlobHeader
+	encodedData = append(encodedData, rawDataPadded...)
 
 	return encodedData, nil
 }
-
 
 func IFFT(data []byte) ([]byte, error) {
 	// we now IFFT data regardless of the encoding type

--- a/eigenda/eigenda.go
+++ b/eigenda/eigenda.go
@@ -16,7 +16,6 @@ const (
 	MaxBatchSize = 2_000_000 // 2MB
 )
 
-
 func IsEigenDAMessageHeaderByte(header byte) bool {
 	return hasBits(header, daprovider.EigenDAMessageHeaderFlag)
 }
@@ -44,8 +43,11 @@ type EigenDA struct {
 	client *EigenDAProxyClient
 }
 
-func NewEigenDA(proxyServerRpc string) (*EigenDA, error) {
-	client := NewEigenDAProxyClient(proxyServerRpc)
+func NewEigenDA(config *EigenDAConfig) (*EigenDA, error) {
+	if !config.Enable {
+		panic("EigenDA is not enabled")
+	}
+	client := NewEigenDAProxyClient(config.Rpc)
 
 	return &EigenDA{
 		client: client,

--- a/eigenda/eigenda.go
+++ b/eigenda/eigenda.go
@@ -2,6 +2,7 @@ package eigenda
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -45,7 +46,7 @@ type EigenDA struct {
 
 func NewEigenDA(config *EigenDAConfig) (*EigenDA, error) {
 	if !config.Enable {
-		panic("EigenDA is not enabled")
+		return nil, errors.New("EigenDA is not enabled")
 	}
 	client := NewEigenDAProxyClient(config.Rpc)
 

--- a/eigenda/proxy.go
+++ b/eigenda/proxy.go
@@ -15,10 +15,9 @@ type EigenDAProxyClient struct {
 	client ProxyClient
 }
 
-func NewEigenDAProxyClient(RPCUrl string) *EigenDAProxyClient {
-
+func NewEigenDAProxyClient(rpcUrl string) *EigenDAProxyClient {
 	c := New(&Config{
-		URL: RPCUrl,
+		URL: rpcUrl,
 	})
 	return &EigenDAProxyClient{client: c}
 }
@@ -89,7 +88,7 @@ func StrToDomainType(s string) DomainType {
 
 // TODO: Add support for custom http client option
 type Config struct {
-	URL   string
+	URL string
 }
 
 // ProxyClient is an interface for communicating with the EigenDA proxy server
@@ -141,7 +140,7 @@ func (c *client) GetData(ctx context.Context, comm []byte, domain DomainType) ([
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct http request: %e", err)
+		return nil, fmt.Errorf("failed to construct http request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/octet-stream")

--- a/eigenda/reader.go
+++ b/eigenda/reader.go
@@ -23,6 +23,8 @@ type readerForEigenDA struct {
 	readerEigenDA EigenDAReader
 }
 
+const sequencerMsgOffset = 41
+
 func (d *readerForEigenDA) IsValidHeaderByte(headerByte byte) bool {
 	return IsEigenDAMessageHeaderByte(headerByte)
 }
@@ -35,8 +37,7 @@ func (d *readerForEigenDA) RecoverPayloadFromBatch(
 	preimageRecorder daprovider.PreimageRecorder,
 	validateSeqMsg bool,
 ) ([]byte, error) {
-	// offset sequencer message at 41
-	return RecoverPayloadFromEigenDABatch(ctx, sequencerMsg[41:], d.readerEigenDA, preimageRecorder, "binary")
+	return RecoverPayloadFromEigenDABatch(ctx, sequencerMsg[sequencerMsgOffset:], d.readerEigenDA, preimageRecorder, "binary")
 }
 
 func RecoverPayloadFromEigenDABatch(ctx context.Context,
@@ -139,6 +140,5 @@ func (d *binaryReaderForEigenDA) RecoverPayloadFromBatch(
 	preimageRecorder daprovider.PreimageRecorder,
 	validateSeqMsg bool,
 ) ([]byte, error) {
-	// offset sequencer message at 41
-	return RecoverPayloadFromEigenDABatch(ctx, sequencerMsg[41:], d.readerEigenDA, preimageRecorder, "binary")
+	return RecoverPayloadFromEigenDABatch(ctx, sequencerMsg[sequencerMsgOffset:], d.readerEigenDA, preimageRecorder, "binary")
 }

--- a/eigenda/reader.go
+++ b/eigenda/reader.go
@@ -35,10 +35,9 @@ func (d *readerForEigenDA) RecoverPayloadFromBatch(
 	preimageRecorder daprovider.PreimageRecorder,
 	validateSeqMsg bool,
 ) ([]byte, error) {
-	// offset sequencer message at 41 
+	// offset sequencer message at 41
 	return RecoverPayloadFromEigenDABatch(ctx, sequencerMsg[41:], d.readerEigenDA, preimageRecorder, "binary")
 }
-
 
 func RecoverPayloadFromEigenDABatch(ctx context.Context,
 	sequencerMsg []byte,
@@ -83,7 +82,7 @@ func RecoverPayloadFromEigenDABatch(ctx context.Context,
 
 // ParseSequencerMsg parses the inbox tx calldata into a structured EigenDABlobInfo
 func ParseSequencerMsg(calldata []byte) (*EigenDABlobInfo, error) {
-	
+
 	if len(calldata) < 4 {
 		return nil, errors.New("calldata is shorter than expected method signature length")
 	}
@@ -140,6 +139,6 @@ func (d *binaryReaderForEigenDA) RecoverPayloadFromBatch(
 	preimageRecorder daprovider.PreimageRecorder,
 	validateSeqMsg bool,
 ) ([]byte, error) {
-	// offset sequencer message at 41 
+	// offset sequencer message at 41
 	return RecoverPayloadFromEigenDABatch(ctx, sequencerMsg[41:], d.readerEigenDA, preimageRecorder, "binary")
 }

--- a/eigenda/types.go
+++ b/eigenda/types.go
@@ -254,9 +254,9 @@ func (e *EigenDABlobInfo) ToDisperserBlobInfo() (*DisperserBlobInfo, error) {
 
 	// Convert BlobVerificationProof
 	var disperserBlobVerificationProof DisperserBlobVerificationProof
-	if &e.BlobVerificationProof != nil {
+	if !e.BlobVerificationProof.IsEmpty() {
 		var disperserBatchMetadata DisperserBatchMetadata
-		if &e.BlobVerificationProof.BatchMetadata != nil {
+		if !e.BlobVerificationProof.BatchMetadata.IsEmpty() {
 			metadata := e.BlobVerificationProof.BatchMetadata
 			quorumNumbers := metadata.BatchHeader.QuorumNumbers
 			quorumSignedPercentages := metadata.BatchHeader.SignedStakeForQuorums
@@ -394,4 +394,30 @@ func (ip *InboxPayload) Load(callDataValues []interface{}) error {
 
 	*ip = payload
 	return nil
+}
+
+// IsEmpty checks if BlobVerificationProof is effectively empty
+func (b BlobVerificationProof) IsEmpty() bool {
+	return b.BatchID == 0 &&
+		b.BlobIndex == 0 &&
+		b.BatchMetadata.IsEmpty() &&
+		len(b.InclusionProof) == 0 &&
+		len(b.QuorumIndices) == 0
+}
+
+// IsEmpty checks if BatchMetadata is effectively empty
+func (bm BatchMetadata) IsEmpty() bool {
+	return bm.BatchHeader.IsEmpty() &&
+		len(bm.Fee) == 0 &&
+		bm.SignatoryRecordHash == [32]byte{} &&
+		bm.ConfirmationBlockNumber == 0 &&
+		len(bm.BatchHeaderHash) == 0
+}
+
+// IsEmpty checks if BatchHeader is effectively empty
+func (bh BatchHeader) IsEmpty() bool {
+	return bh.BlobHeadersRoot == [32]byte{} &&
+		len(bh.QuorumNumbers) == 0 &&
+		len(bh.SignedStakeForQuorums) == 0 &&
+		bh.ReferenceBlockNumber == 0
 }

--- a/validator/server_jit/jit_machine.go
+++ b/validator/server_jit/jit_machine.go
@@ -67,7 +67,6 @@ func (machine *JitMachine) close() {
 func (machine *JitMachine) prove(
 	ctxIn context.Context, entry *validator.ValidationInput,
 ) (validator.GoGlobalState, error) {
-	
 
 	ctx, cancel := context.WithCancel(ctxIn)
 	defer cancel() // ensure our cleanup functions run when we're done


### PR DESCRIPTION
(disclaimer: I'm not usually this talkative with PR comments, being unusual because I'm new and trying to become familiar with things)

This PR contains minor refactoring to make the linter happy 

For the custom `go run ./linters ./...`, the only complain was  
```
 ✗ go run ./linters ./...
.../nitro/eigenda/eigenda.go:36:2: field eigenda.EigenDAConfig.Enable not used
.../nitro/eigenda/eigenda.go:37:2: field eigenda.EigenDAConfig.Rpc not used
exit status 3
```

As a new gopher, I've tried using `unused: ignore-field` in `.golang.ci.yml`, adding ` used:"true"` as part of field definitions, `//nolint:unused` to disable check for the config struct, modifying the structinit.go analyzer, but nothing worked until I made a dumb initializer for the struct 🤦  If I'm missing anything obvious, please let me know and I will make smarter changes.
So then, reviewing that `EigenDAConfig` is only used for initializing `EigenDAClient`, I think it makes sense to have arbnode pass in the config struct instead of only the `RPC` field. If we want more granular control of client initailization in the future, this change is probably in the right direction. Also included an additional/duplicate check for `Enable` to make linter happy; I think we can delete this check in arbnode, but I'm nervous about safety in golang


#### `golangci-lint` 
a couple of failures there, change explanations:

all files got `go fmt`ed. 
~~`go sec`~~

```
arbnode/dataposter/data_poster.go:223:23: G402: TLS InsecureSkipVerify may be true. (gosec)
-> #nosec moved to group config (https://github.com/securego/gosec/issues/278#issuecomment-461251791)
```
^ this is okay when updated local to 1.59.1

`go critic`

```
eigenda/decoding.go:119:17: appendAssign: append result not assigned to the same slice (gocritic)
        encodedData := append(codecBlobHeader, rawDataPadded...)
                       ^
->  keep using append by assign it back to the original slice
eigenda/proxy.go:18:28: captLocal: `RPCUrl' should not be capitalized (gocritic)
func NewEigenDAProxyClient(RPCUrl string) *EigenDAProxyClient {
                           ^
-> replace `RPCUrl` with `rpcUrl`
arbnode/sequencer_inbox.go:178:23: unslice: could simplify calldata[:] to calldata (gocritic)
                data = append(data, calldata[:]...)
                                    ^
-> simplified
```

`errorlint`
```
eigenda/proxy.go:143:66: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                return nil, fmt.Errorf("failed to construct http request: %e", err)
                                                            ^
-> %e to %w                                             
```
                   
`govet`
```
eigenda/types.go:257:30: nilness: tautological condition: non-nil != nil (govet)
        if &e.BlobVerificationProof != nil {
                                    ^
eigenda/types.go:259:45: nilness: tautological condition: non-nil != nil (govet)
                if &e.BlobVerificationProof.BatchMetadata != nil {
                                                          ^
-> always tautological since taking the address of a struct field will always return a non-nil pointer even if the field itself is a nil pointer or has a zero value.
-> added IsEmpty helpers for structs and use that for the checks
```


🤞 let's see if CI will pass