### PR TITLE
feat: bump max EigenDA batch size to 16mib

### DIFF
--- a/.github/workflows/docker-eigenda.yml
+++ b/.github/workflows/docker-eigenda.yml
@@ -1,8 +1,6 @@
 name: Build nitro-eigenda Docker Image
 on:
   workflow_dispatch:
-  push:
-    tags: ['*']
 
 jobs:
   docker:

--- a/.github/workflows/shellcheck-ci.yml
+++ b/.github/workflows/shellcheck-ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   shellcheck:
     name: Run ShellCheck
-    runs-on: ubuntu-8
+    runs-on: linux-2xl
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -245,7 +245,7 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	DisableDapFallbackStoreDataOnChain: false,
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
 	MaxSize:             100000,
-	MaxEigenDABatchSize: 2_000_000,
+	MaxEigenDABatchSize: 16_000_000,
 	// Try to fill 3 blobs per batch
 	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
 	PollInterval:                   time.Second * 10,

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -245,7 +245,7 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	DisableDapFallbackStoreDataOnChain: false,
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
 	MaxSize:             100000,
-	MaxEigenDABatchSize: 16_000_000,
+	MaxEigenDABatchSize: 16_777_216,
 	// Try to fill 3 blobs per batch
 	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
 	PollInterval:                   time.Second * 10,

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -45,7 +45,7 @@ type sequencerMessage struct {
 	segments             [][]byte
 }
 
-const MaxDecompressedLen int = 1024 * 1024 * 16 // 16 MiB
+const MaxDecompressedLen int = 1024 * 1024 * 16 * 40 // 40 MiB
 const maxZeroheavyDecompressedLen = 101*MaxDecompressedLen/100 + 64
 const MaxSegmentsPerSequencerMessage = 100 * 1024
 

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -45,7 +45,7 @@ type sequencerMessage struct {
 	segments             [][]byte
 }
 
-const MaxDecompressedLen int = 1024 * 1024 * 16 * 40 // 40 MiB
+const MaxDecompressedLen int = 1024 * 1024 * 40 // 40 MiB
 const maxZeroheavyDecompressedLen = 101*MaxDecompressedLen/100 + 64
 const MaxSegmentsPerSequencerMessage = 100 * 1024
 

--- a/eigenda/eigenda.go
+++ b/eigenda/eigenda.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	sequencerMsgOffset = 41
-	MaxBatchSize       = 2_000_000 // 2MB
+	MaxBatchSize       = 16_000_000 // 16MB
 )
 
 func IsEigenDAMessageHeaderByte(header byte) bool {

--- a/eigenda/eigenda.go
+++ b/eigenda/eigenda.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	sequencerMsgOffset = 41
-	MaxBatchSize       = 16_000_000 // 16MB
+	MaxBatchSize       = 16_777_216 // 16MiB
 )
 
 func IsEigenDAMessageHeaderByte(header byte) bool {

--- a/scripts/start-eigenda-proxy.sh
+++ b/scripts/start-eigenda-proxy.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo "Pull eigenda-proxy container"
 docker pull  ghcr.io/layr-labs/eigenda-proxy@sha256:10a4762f5c43e9037835617e6ec0b03da34012df87048a363f43b969ab93679b
 


### PR DESCRIPTION
**Changes**
- Increase `MaxEigenDABatchSize` to 16 MB
- Increase `maxDecompressionLen` to 40 mib. This constraint was causing the batch poster to detect overflows and limit the batches to 5-7mb post-compression using a constant ratio of 4. Increasing it resulted in batches around exactly 16MB post compression.

**Testing**
Tests were conducted against a testnode environment on an EC2 using EigenDA Holesky. Under higher load (i.e, 90 Kb/s) and reduced EigenDA bridge intervals (i.e, 3 minutes), the chain was able to maintain liveness with the latest->confirmed message diff being constant over multiple hours of load.

<img width="710" alt="Screenshot 2024-09-30 at 9 38 02 PM" src="https://github.com/user-attachments/assets/87d46316-71dd-49be-bccd-f92fe348c082">
<img width="718" alt="Screenshot 2024-10-01 at 2 22 10 PM" src="https://github.com/user-attachments/assets/c3533446-00c9-4b90-b714-58f4489982ba">
<img width="1424" alt="Screenshot 2024-10-01 at 2 23 03 PM" src="https://github.com/user-attachments/assets/b8cb50ed-d4ec-4b40-a27d-032183f13c7f">


