### PR TITLE
fix: Support cross compatibility with vanilla consensus-v32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS brotli-wasm-builder
+    FROM debian:bookworm-slim AS brotli-wasm-builder
 WORKDIR /workspace
 RUN apt-get update && \
     apt-get install -y cmake make git lbzip2 python3 xz-utils && \
@@ -228,7 +228,9 @@ COPY ./scripts/download-machine.sh .
 #RUN ./download-machine.sh consensus-v20 0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4
 # RUN ./download-machine.sh consensus-v30 0xb0de9cb89e4d944ae6023a3b62276e54804c242fd8c4c2d8e6cc4450f5fa8b1b && true
 # RUN ./download-machine.sh consensus-v31 0x260f5fa5c3176a856893642e149cf128b5a8de9f828afec8d11184415dd8dc69
-# RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
+RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
+# TODO: Insert eigenda machine here once we're post audit and have a final artifact to push
+# RUN ./download-machine.sh consensus-eigenda-v32 0x...0
 
 FROM golang:1.21.10-bookworm AS node-builder
 WORKDIR /workspace

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1258,12 +1258,6 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 				allMsgs:     make(map[arbutil.MessageIndex]*arbostypes.MessageWithMetadata),
 			}
 		}
-		if b.config().CheckBatchCorrectness {
-			b.building.muxBackend = &simulatedMuxBackend{
-				batchSeqNum: batchPosition.NextSeqNum,
-				allMsgs:     make(map[arbutil.MessageIndex]*arbostypes.MessageWithMetadata),
-			}
-		}
 	}
 	msgCount, err := b.streamer.GetMessageCount()
 	if err != nil {

--- a/scripts/download-machine-eigenda.sh
+++ b/scripts/download-machine-eigenda.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+mkdir "$2"
+ln -sfT "$2" latest
+cd "$2"
+echo "$2" > module-root.txt
+url_base="https://github.com/Layr-Labs/nitro/releases/download/$1"
+wget "$url_base/machine.wavm.br"
+
+status_code="$(curl -LI "$url_base/replay.wasm" -so /dev/null -w '%{http_code}')"
+if [ "$status_code" -ne 404 ]; then
+	wget "$url_base/replay.wasm"
+fi


### PR DESCRIPTION
**Changes**
- Fetch `consensus-v32` for backwards compatibility with existing vanilla arbitrum chains 
- Remove duplicate config check in `batch_poster`
- Extended artifact fetching script for `layr-labs/nitro` 