### PR TITLE
feat: EigenDA failover

### DIFF
--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -149,7 +149,7 @@ type BatchPosterDangerousConfig struct {
 type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
-	EnableEigenDAFailover    bool `koanf:"eigenda-failover-to-anytrust" reload:"hot"`
+	EnableEigenDAFailover              bool `koanf:"eigenda-failover-to-anytrust" reload:"hot"`
 	// Max batch size.
 	MaxSize int `koanf:"max-size" reload:"hot"`
 	// Maximum 4844 blob enabled batch size.
@@ -248,8 +248,8 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	DisableDapFallbackStoreDataOnChain: false,
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
 	EnableEigenDAFailover: false,
-	MaxSize:                         100000,
-	MaxEigenDABatchSize:             16_777_216,
+	MaxSize:               100000,
+	MaxEigenDABatchSize:   16_777_216,
 	// Try to fill 3 blobs per batch
 	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
 	PollInterval:                   time.Second * 10,

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -150,7 +150,8 @@ type BatchPosterDangerousConfig struct {
 type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
-	EnableEigenDAFailover              bool `koanf:"eigenda-failover" reload:"hot"`
+	// Enable failover to AnyTrust (if enabled) or native ETH DA if EigenDA fails.
+	EnableEigenDAFailover              bool `koanf:"enable-eigenda-failover" reload:"hot"`
 	// Max batch size.
 	MaxSize int `koanf:"max-size" reload:"hot"`
 	// Maximum 4844 blob enabled batch size.
@@ -217,7 +218,7 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
 	f.Bool(prefix+".disable-dap-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDapFallbackStoreDataOnChain, "If unable to batch to DA provider, disable fallback storing data on chain")
-	f.Bool(prefix+".eigenda-failover", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust (if enabled) or native ETH DA")
+	f.Bool(prefix+".enable-eigenda-failover", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust (if enabled) or native ETH DA")
 	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxSize, "maximum batch size")
 	f.Int(prefix+".max-4844-batch-size", DefaultBatchPosterConfig.Max4844BatchSize, "maximum 4844 blob enabled batch size")
 	f.Int(prefix+".max-eigenda-batch-size", DefaultBatchPosterConfig.MaxEigenDABatchSize, "maximum EigenDA blob enabled batch size")
@@ -330,7 +331,7 @@ var EigenDABatchPosterConfig = BatchPosterConfig{
 	L1BlockBoundBypass:             time.Hour,
 	UseAccessLists:                 true,
 	GasEstimateBaseFeeMultipleBips: arbmath.OneInUBips * 3 / 2,
-	CheckBatchCorrectness:          false,
+	CheckBatchCorrectness:          true,
 }
 
 type BatchPosterOpts struct {

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -150,7 +150,7 @@ type BatchPosterDangerousConfig struct {
 type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
-	EnableEigenDAFailover              bool `koanf:"eigenda-failover" reload:"hot"`
+	EnableEigenDAFailover              bool `koanf:"enable-eigenda-failover" reload:"hot"`
 	// Max batch size.
 	MaxSize int `koanf:"max-size" reload:"hot"`
 	// Maximum 4844 blob enabled batch size.
@@ -217,7 +217,7 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
 	f.Bool(prefix+".disable-dap-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDapFallbackStoreDataOnChain, "If unable to batch to DA provider, disable fallback storing data on chain")
-	f.Bool(prefix+".eigenda-failover", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust (if enabled) or native ETH DA")
+	f.Bool(prefix+".enable-eigenda-failover", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust (if enabled) or native ETH DA")
 	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxSize, "maximum batch size")
 	f.Int(prefix+".max-4844-batch-size", DefaultBatchPosterConfig.Max4844BatchSize, "maximum 4844 blob enabled batch size")
 	f.Int(prefix+".max-eigenda-batch-size", DefaultBatchPosterConfig.MaxEigenDABatchSize, "maximum EigenDA blob enabled batch size")

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -1509,9 +1509,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 
 		if failOver {
 			batchPosterDAFailoverCount.Inc(1)
-		}
-
-		if err == nil {
+		} else {
 			batchPosterDASuccessCounter.Inc(1)
 			batchPosterDALastSuccessfulActionGauge.Update(time.Now().Unix())
 			eigenDADispersed = true

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -71,6 +71,7 @@ var (
 	batchPosterDALastSuccessfulActionGauge = metrics.NewRegisteredGauge("arb/batchPoster/action/da_last_success", nil)
 	batchPosterDASuccessCounter            = metrics.NewRegisteredCounter("arb/batchPoster/action/da_success", nil)
 	batchPosterDAFailureCounter            = metrics.NewRegisteredCounter("arb/batchPoster/action/da_failure", nil)
+	batchPosterDAFailoverCount             = metrics.NewRegisteredCounter("arb/batchPoster/action/da_failover", nil)
 
 	batchPosterFailureCounter = metrics.NewRegisteredCounter("arb/batchPoster/action/failure", nil)
 
@@ -122,10 +123,10 @@ type BatchPoster struct {
 	backlog         atomic.Uint64
 	lastHitL1Bounds time.Time // The last time we wanted to post a message but hit the L1 bounds
 
-	batchReverted        atomic.Bool // indicates whether data poster batch was reverted
-	nextRevertCheckBlock int64       // the last parent block scanned for reverting batches
-	postedFirstBatch     bool        // indicates if batch poster has posted the first batch
-	failoverETHDA        bool        // indicates if batch poster should failover to ETHDA
+	batchReverted          atomic.Bool // indicates whether data poster batch was reverted
+	nextRevertCheckBlock   int64       // the last parent block scanned for reverting batches
+	postedFirstBatch       bool        // indicates if batch poster has posted the first batch
+	eigenDAFailoverToETHDA bool        // indicates if batch poster should failover to ETHDA
 
 	accessList func(SequencerInboxAccs, AfterDelayedMessagesRead uint64) types.AccessList
 }
@@ -149,7 +150,7 @@ type BatchPosterDangerousConfig struct {
 type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
-	EnableEigenDAFailover              bool `koanf:"eigenda-failover-to-anytrust" reload:"hot"`
+	EnableEigenDAFailover              bool `koanf:"eigenda-failover" reload:"hot"`
 	// Max batch size.
 	MaxSize int `koanf:"max-size" reload:"hot"`
 	// Maximum 4844 blob enabled batch size.
@@ -216,7 +217,7 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
 	f.Bool(prefix+".disable-dap-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDapFallbackStoreDataOnChain, "If unable to batch to DA provider, disable fallback storing data on chain")
-	f.Bool(prefix+".eigenda-failover-to-anytrust", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust")
+	f.Bool(prefix+".eigenda-failover", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust (if enabled) or native ETH DA")
 	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxSize, "maximum batch size")
 	f.Int(prefix+".max-4844-batch-size", DefaultBatchPosterConfig.Max4844BatchSize, "maximum 4844 blob enabled batch size")
 	f.Int(prefix+".max-eigenda-batch-size", DefaultBatchPosterConfig.MaxEigenDABatchSize, "maximum EigenDA blob enabled batch size")
@@ -1253,7 +1254,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		}
 
 		var useEigenDA bool
-		if b.eigenDAWriter != nil && !b.failoverETHDA {
+		if b.eigenDAWriter != nil && !b.eigenDAFailoverToETHDA {
 			useEigenDA = true
 		}
 
@@ -1458,7 +1459,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	eigenDADispersed := false
 	failOver := false
 
-	if b.eigenDAWriter != nil && !b.failoverETHDA {
+	if b.eigenDAWriter != nil && !b.eigenDAFailoverToETHDA {
 		if !b.redisLock.AttemptLock(ctx) {
 			return false, errAttemptLockFailed
 		}
@@ -1482,18 +1483,32 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 
 		if err != nil && errors.Is(err, eigenda.SvcUnavailableErr) && b.config().EnableEigenDAFailover && b.dapWriter == nil { // Failover to ETH DA if enabled
 			// when failing over to ETHDA (i.e 4844, calldata), we may need to re-encode the batch. To do this in compliance with the existing code, it's easiest
-			// to update an internal field and retrigger the poster's event loop. Since this update should be down across batch posters on a distributed cluster, we
-			// must also
+			// to update an internal field and retrigger the poster's event loop. Since the batch poster can be distributed across mulitple nodes, there could be
+			// degraded temporary performance as each batch poster will re-encode the batch on another event loop tick using the coordination lock which could worst case
+			// could require every batcher instance to fail dispersal to EigenDA.
+			// However, this is a rare event and the performance impact is minimal.
+
 			log.Error("EigenDA service is unavailable and anytrust is disabled, failing over to ETH DA")
-			b.failoverETHDA = true
-			b.building = nil
-			return false, nil
+			b.eigenDAFailoverToETHDA = true
+
+			// // if the batch's size exceeds the native DA max size limit, we must re-encode the batch to accomodate the AnyTrust, calldata, and 4844 size limits
+			if (len(sequencerMsg) > b.config().MaxSize && !b.building.use4844) || (len(sequencerMsg) > b.config().Max4844BatchSize && b.building.use4844) {
+				batchPosterDAFailureCounter.Inc(1)
+				batchPosterDAFailoverCount.Inc(1)
+
+				b.building = nil
+				return false, nil
+			}
 
 		}
 
-		if err != nil && !failOver { //
+		if err != nil {
 			batchPosterDAFailureCounter.Inc(1)
 			return false, err
+		}
+
+		if failOver {
+			batchPosterDAFailoverCount.Inc(1)
 		}
 
 		if err == nil {
@@ -1586,8 +1601,8 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		return false, err
 	}
 
-	if !b.building.useEigenDA && b.failoverETHDA {
-		b.failoverETHDA = false
+	if !b.building.useEigenDA && b.eigenDAFailoverToETHDA {
+		b.eigenDAFailoverToETHDA = false
 	}
 
 	if config.CheckBatchCorrectness {

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -151,7 +151,7 @@ type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
 	// Enable failover to AnyTrust (if enabled) or native ETH DA if EigenDA fails.
-	EnableEigenDAFailover              bool `koanf:"enable-eigenda-failover" reload:"hot"`
+	EnableEigenDAFailover bool `koanf:"enable-eigenda-failover" reload:"hot"`
 	// Max batch size.
 	MaxSize int `koanf:"max-size" reload:"hot"`
 	// Maximum 4844 blob enabled batch size.

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -150,7 +150,7 @@ type BatchPosterDangerousConfig struct {
 type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
-	EnableEigenDAFailover              bool `koanf:"enable-eigenda-failover" reload:"hot"`
+	EnableEigenDAFailover              bool `koanf:"eigenda-failover" reload:"hot"`
 	// Max batch size.
 	MaxSize int `koanf:"max-size" reload:"hot"`
 	// Maximum 4844 blob enabled batch size.
@@ -217,7 +217,7 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
 	f.Bool(prefix+".disable-dap-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDapFallbackStoreDataOnChain, "If unable to batch to DA provider, disable fallback storing data on chain")
-	f.Bool(prefix+".enable-eigenda-failover", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust (if enabled) or native ETH DA")
+	f.Bool(prefix+".eigenda-failover", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust (if enabled) or native ETH DA")
 	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxSize, "maximum batch size")
 	f.Int(prefix+".max-4844-batch-size", DefaultBatchPosterConfig.Max4844BatchSize, "maximum 4844 blob enabled batch size")
 	f.Int(prefix+".max-eigenda-batch-size", DefaultBatchPosterConfig.MaxEigenDABatchSize, "maximum EigenDA blob enabled batch size")
@@ -1502,12 +1502,11 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 
 		}
 
-		if err != nil {
+		if err != nil && !failOver {
 			batchPosterDAFailureCounter.Inc(1)
 			return false, err
-		}
 
-		if failOver {
+		} else if failOver {
 			batchPosterDAFailoverCount.Inc(1)
 		} else {
 			batchPosterDASuccessCounter.Inc(1)

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -109,7 +109,7 @@ type BatchPoster struct {
 	building           *buildingBatch
 	dapWriter          daprovider.Writer
 	// This deviates from the DA spec but is necessary for the batch poster to work efficiently
-	// since we need to an extended method on the SequencerInbox contract
+	// since we need to an extended method on the SequencerInbox contract for posting EigenDA certificates
 	eigenDAWriter     eigenda.EigenDAWriter
 	dapReaders        []daprovider.Reader
 	dataPoster        *dataposter.DataPoster
@@ -125,6 +125,7 @@ type BatchPoster struct {
 	batchReverted        atomic.Bool // indicates whether data poster batch was reverted
 	nextRevertCheckBlock int64       // the last parent block scanned for reverting batches
 	postedFirstBatch     bool        // indicates if batch poster has posted the first batch
+	failoverETHDA        bool        // indicates if batch poster should failover to ETHDA
 
 	accessList func(SequencerInboxAccs, AfterDelayedMessagesRead uint64) types.AccessList
 }
@@ -148,6 +149,7 @@ type BatchPosterDangerousConfig struct {
 type BatchPosterConfig struct {
 	Enable                             bool `koanf:"enable"`
 	DisableDapFallbackStoreDataOnChain bool `koanf:"disable-dap-fallback-store-data-on-chain" reload:"hot"`
+	EnableEigenDAFailover    bool `koanf:"eigenda-failover-to-anytrust" reload:"hot"`
 	// Max batch size.
 	MaxSize int `koanf:"max-size" reload:"hot"`
 	// Maximum 4844 blob enabled batch size.
@@ -214,6 +216,7 @@ type BatchPosterConfigFetcher func() *BatchPosterConfig
 func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.Bool(prefix+".enable", DefaultBatchPosterConfig.Enable, "enable posting batches to l1")
 	f.Bool(prefix+".disable-dap-fallback-store-data-on-chain", DefaultBatchPosterConfig.DisableDapFallbackStoreDataOnChain, "If unable to batch to DA provider, disable fallback storing data on chain")
+	f.Bool(prefix+".eigenda-failover-to-anytrust", DefaultBatchPosterConfig.EnableEigenDAFailover, "If EigenDA fails, failover to AnyTrust")
 	f.Int(prefix+".max-size", DefaultBatchPosterConfig.MaxSize, "maximum batch size")
 	f.Int(prefix+".max-4844-batch-size", DefaultBatchPosterConfig.Max4844BatchSize, "maximum 4844 blob enabled batch size")
 	f.Int(prefix+".max-eigenda-batch-size", DefaultBatchPosterConfig.MaxEigenDABatchSize, "maximum EigenDA blob enabled batch size")
@@ -244,8 +247,9 @@ var DefaultBatchPosterConfig = BatchPosterConfig{
 	Enable:                             false,
 	DisableDapFallbackStoreDataOnChain: false,
 	// This default is overridden for L3 chains in applyChainParameters in cmd/nitro/nitro.go
-	MaxSize:             100000,
-	MaxEigenDABatchSize: 16_777_216,
+	EnableEigenDAFailover: false,
+	MaxSize:                         100000,
+	MaxEigenDABatchSize:             16_777_216,
 	// Try to fill 3 blobs per batch
 	Max4844BatchSize:               blobs.BlobEncodableData*(params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)/2 - 2000,
 	PollInterval:                   time.Second * 10,
@@ -569,6 +573,14 @@ func (b *BatchPoster) getTxsInfoByBlock(ctx context.Context, number int64) ([]tx
 		return nil, fmt.Errorf("error fetching block %d : %w", number, err)
 	}
 	return blk.Transactions, nil
+}
+
+func (b *BatchPoster) SetEigenDAClientMock() {
+	b.eigenDAWriter = eigenda.NewMockEigenDA(true)
+}
+
+func (b *BatchPoster) SetEigenDAWriter(writer eigenda.EigenDAWriter) {
+	b.eigenDAWriter = writer
 }
 
 // checkRevert checks blocks with number in range [from, to] whether they
@@ -1241,7 +1253,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		}
 
 		var useEigenDA bool
-		if b.eigenDAWriter != nil {
+		if b.eigenDAWriter != nil && !b.failoverETHDA {
 			useEigenDA = true
 		}
 
@@ -1442,7 +1454,56 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		return false, nil
 	}
 
-	if b.dapWriter != nil {
+	var eigenDaBlobInfo *eigenda.EigenDABlobInfo
+	eigenDADispersed := false
+	failOver := false
+
+	if b.eigenDAWriter != nil && !b.failoverETHDA {
+		if !b.redisLock.AttemptLock(ctx) {
+			return false, errAttemptLockFailed
+		}
+
+		gotNonce, gotMeta, err := b.dataPoster.GetNextNonceAndMeta(ctx)
+		if err != nil {
+			batchPosterDAFailureCounter.Inc(1)
+			return false, err
+		}
+		if nonce != gotNonce || !bytes.Equal(batchPositionBytes, gotMeta) {
+			batchPosterDAFailureCounter.Inc(1)
+			return false, fmt.Errorf("%w: nonce changed from %d to %d while creating batch", storage.ErrStorageRace, nonce, gotNonce)
+		}
+		eigenDaBlobInfo, err = b.eigenDAWriter.Store(ctx, sequencerMsg)
+
+		if err != nil && errors.Is(err, eigenda.SvcUnavailableErr) && b.config().EnableEigenDAFailover && b.dapWriter != nil { // Failover to anytrust commitee if enabled
+			log.Error("EigenDA service is unavailable, failing over to any trust mode")
+			b.building.useEigenDA = false
+			failOver = true
+		}
+
+		if err != nil && errors.Is(err, eigenda.SvcUnavailableErr) && b.config().EnableEigenDAFailover && b.dapWriter == nil { // Failover to ETH DA if enabled
+			// when failing over to ETHDA (i.e 4844, calldata), we may need to re-encode the batch. To do this in compliance with the existing code, it's easiest
+			// to update an internal field and retrigger the poster's event loop. Since this update should be down across batch posters on a distributed cluster, we
+			// must also
+			log.Error("EigenDA service is unavailable and anytrust is disabled, failing over to ETH DA")
+			b.failoverETHDA = true
+			b.building = nil
+			return false, nil
+
+		}
+
+		if err != nil && !failOver { //
+			batchPosterDAFailureCounter.Inc(1)
+			return false, err
+		}
+
+		if err == nil {
+			batchPosterDASuccessCounter.Inc(1)
+			batchPosterDALastSuccessfulActionGauge.Update(time.Now().Unix())
+			eigenDADispersed = true
+		}
+	}
+
+	if b.dapWriter != nil && !eigenDADispersed {
 		if !b.redisLock.AttemptLock(ctx) {
 			return false, errAttemptLockFailed
 		}
@@ -1458,28 +1519,6 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		}
 		// #nosec G115
 		sequencerMsg, err = b.dapWriter.Store(ctx, sequencerMsg, uint64(time.Now().Add(config.DASRetentionPeriod).Unix()), config.DisableDapFallbackStoreDataOnChain)
-		if err != nil {
-			batchPosterDAFailureCounter.Inc(1)
-			return false, err
-		}
-
-		batchPosterDASuccessCounter.Inc(1)
-		batchPosterDALastSuccessfulActionGauge.Update(time.Now().Unix())
-	}
-
-	var eigenDaBlobInfo *eigenda.EigenDABlobInfo
-	if b.eigenDAWriter != nil {
-
-		gotNonce, gotMeta, err := b.dataPoster.GetNextNonceAndMeta(ctx)
-		if err != nil {
-			batchPosterDAFailureCounter.Inc(1)
-			return false, err
-		}
-		if nonce != gotNonce || !bytes.Equal(batchPositionBytes, gotMeta) {
-			batchPosterDAFailureCounter.Inc(1)
-			return false, fmt.Errorf("%w: nonce changed from %d to %d while creating batch", storage.ErrStorageRace, nonce, gotNonce)
-		}
-		eigenDaBlobInfo, err = b.eigenDAWriter.Store(ctx, sequencerMsg)
 		if err != nil {
 			batchPosterDAFailureCounter.Inc(1)
 			return false, err
@@ -1547,6 +1586,10 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 		return false, err
 	}
 
+	if !b.building.useEigenDA && b.failoverETHDA {
+		b.failoverETHDA = false
+	}
+
 	if config.CheckBatchCorrectness {
 		dapReaders := b.dapReaders
 		if b.building.use4844 {
@@ -1598,6 +1641,7 @@ func (b *BatchPoster) maybePostSequencerBatch(ctx context.Context) (bool, error)
 	log.Info(
 		"BatchPoster: batch sent",
 		"eigenDA", b.building.useEigenDA,
+		"4844", b.building.use4844,
 		"sequenceNumber", batchPosition.NextSeqNum,
 		"from", batchPosition.MessageCount,
 		"to", b.building.msgCount,

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -587,8 +587,8 @@ func createNodeImpl(
 		return nil, errors.New("eigenDA and anytrust cannot both be enabled without EnableEigenDAFailover=true in batch poster config")
 	}
 
-	if config.EigenDA.Enable { // anytrust is enabled as an EigenDA failover
-		log.Info("EigenDA enabled")
+	if config.EigenDA.Enable {
+		log.Info("EigenDA enabled", "failover", config.BatchPoster.EnableEigenDAFailover, "anytrust", config.DataAvailability.Enable)
 		eigenDAService, err := eigenda.NewEigenDA(&config.EigenDA)
 		if err != nil {
 			return nil, err

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -210,6 +210,11 @@ func ConfigDefaultL1NonSequencerTest() *Config {
 	return &config
 }
 
+func (cfg *Config) WithEigenDATestConfigParams() *Config {
+	cfg.EigenDA.Enable = true
+	cfg.EigenDA.Rpc = "http://localhost:4242"
+	return cfg
+}
 func ConfigDefaultL2Test() *Config {
 	config := ConfigDefault
 	config.Dangerous = TestDangerousConfig
@@ -576,7 +581,13 @@ func createNodeImpl(
 		}
 	} else if l2Config.ArbitrumChainParams.DataAvailabilityCommittee {
 		return nil, errors.New("a data availability service is required for this chain, but it was not configured")
-	} else if config.EigenDA.Enable {
+	}
+
+	if config.EigenDA.Enable && config.DataAvailability.Enable && !config.BatchPoster.EnableEigenDAFailover {
+		return nil, errors.New("eigenDA and anytrust cannot both be enabled without EnableEigenDAFailover=true in batch poster config")
+	}
+
+	if config.EigenDA.Enable { // anytrust is enabled as an EigenDA failover
 		log.Info("EigenDA enabled")
 		eigenDAService, err := eigenda.NewEigenDA(&config.EigenDA)
 		if err != nil {

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -247,7 +247,9 @@ func main() {
 			// DAS batch and keysets are all together in the same preimage binary.
 			dasReader = &PreimageDASReader{}
 			dasKeysetFetcher = &PreimageDASReader{}
-		} else if eigenDAEnabled {
+		}
+
+		if eigenDAEnabled {
 			eigenDAReader = &EigenDAPreimageReader{}
 		}
 		backend := WavmInbox{}

--- a/eigenda/proxy.go
+++ b/eigenda/proxy.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+var (
+	SvcUnavailableErr = fmt.Errorf("eigenda service is unavailable")
+)
+
 type EigenDAProxyClient struct {
 	client ProxyClient
 }
@@ -121,6 +125,10 @@ func (c *client) GetData(ctx context.Context, comm []byte) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("received unexpected response code: %d", resp.StatusCode)
+	}
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, SvcUnavailableErr
 	}
 
 	return io.ReadAll(resp.Body)

--- a/eigenda/proxy_mock.go
+++ b/eigenda/proxy_mock.go
@@ -1,0 +1,110 @@
+package eigenda
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Layr-Labs/eigenda/api/grpc/disperser"
+)
+
+var (
+	mockCert       = []byte{0x01, 0x02, 0x03, 0x04}
+	mockBlobData   = []byte("mock data")
+	mockBlobInfo   = disperser.BlobInfo{}
+	mockHealthErr  = errors.New("service unavailable")
+	mockServiceErr = fmt.Errorf("mock error: failed to store data")
+)
+
+// MockEigenDA implements the EigenDA interface using the mock client.
+type MockEigenDA struct {
+	client *MockEigenDAProxyClient
+}
+
+// NewMockEigenDA initializes the mock EigenDA instance.
+func NewMockEigenDA(fallbackErr bool) *MockEigenDA {
+	client := NewMockEigenDAProxyClient(fallbackErr)
+	return &MockEigenDA{client: client}
+}
+
+// QueryBlob mocks the QueryBlob function.
+func (e *MockEigenDA) QueryBlob(ctx context.Context, cert *EigenDABlobInfo, domainFilter string) ([]byte, error) {
+	return []byte("mockData"), nil
+}
+
+// Store mocks the Store function, returning mock EigenDABlobInfo.
+func (e *MockEigenDA) Store(ctx context.Context, data []byte) (*EigenDABlobInfo, error) {
+	var blobInfo = &EigenDABlobInfo{}
+	cert, err := e.client.Put(ctx, data)
+	if err != nil {
+		return nil, err
+	}
+
+	blobInfo.LoadBlobInfo(cert)
+
+	return blobInfo, nil
+}
+
+// Serialize mocks the Serialize function, returning a simple byte slice.
+func (e *MockEigenDA) Serialize(blobInfo *EigenDABlobInfo) ([]byte, error) {
+	return []byte("mockSerializedData"), nil
+}
+
+type MockProxyClient struct {
+	ShouldFail      bool // Flag to toggle failure modes
+	ShouldReturn503 bool
+}
+
+func NewMockProxyClient(failover bool) ProxyClient {
+	return &MockProxyClient{
+		ShouldFail: failover,
+	}
+}
+
+func (m *MockProxyClient) Health() error {
+	if m.ShouldFail {
+		return mockHealthErr
+	}
+	return nil
+}
+
+func (m *MockProxyClient) GetData(ctx context.Context, cert []byte) ([]byte, error) {
+	if m.ShouldFail {
+		return nil, fmt.Errorf("mock error: failed to get data")
+	}
+	return mockBlobData, nil
+}
+
+func (m *MockProxyClient) SetData(ctx context.Context, data []byte) ([]byte, error) {
+	if m.ShouldFail {
+		return nil, mockServiceErr
+	}
+	return mockCert, nil
+}
+
+type MockEigenDAProxyClient struct {
+	client ProxyClient
+}
+
+func NewMockEigenDAProxyClient(shouldFail bool) *MockEigenDAProxyClient {
+	return &MockEigenDAProxyClient{client: NewMockProxyClient(shouldFail)}
+}
+
+func (c *MockEigenDAProxyClient) Put(ctx context.Context, data []byte) (*disperser.BlobInfo, error) {
+	if c.client.(*MockProxyClient).ShouldFail {
+		return nil, SvcUnavailableErr
+	}
+	return &mockBlobInfo, nil
+}
+
+func (c *MockEigenDAProxyClient) Get(ctx context.Context, blobInfo *disperser.BlobInfo) ([]byte, error) {
+	if c.client.(*MockProxyClient).ShouldFail {
+		return nil, fmt.Errorf("mock error: failed to get data")
+	}
+
+	if c.client.(*MockProxyClient).ShouldReturn503 {
+		return nil, SvcUnavailableErr
+	}
+
+	return mockBlobData, nil
+}

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -188,7 +188,7 @@ func checkBatchPosting(t *testing.T, ctx context.Context, l1client, l2clientA *e
 	for _, client := range l2ClientsToCheck {
 		_, err = WaitForTx(ctx, client, tx.Hash(), time.Second*30)
 		Require(t, err)
-
+		
 		l2balance, err := client.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
 		Require(t, err)
 

--- a/system_tests/das_test.go
+++ b/system_tests/das_test.go
@@ -188,7 +188,7 @@ func checkBatchPosting(t *testing.T, ctx context.Context, l1client, l2clientA *e
 	for _, client := range l2ClientsToCheck {
 		_, err = WaitForTx(ctx, client, tx.Hash(), time.Second*30)
 		Require(t, err)
-		
+
 		l2balance, err := client.BalanceAt(ctx, l2info.GetAddress("User2"), nil)
 		Require(t, err)
 

--- a/system_tests/eigenda_test.go
+++ b/system_tests/eigenda_test.go
@@ -102,7 +102,6 @@ func TestEigenDAProxyFailOverToETHDA(t *testing.T) {
 		// 1 - Ensure that batches can be submitted and read via EigenDA batch posting
 		checkEigenDABatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12), l2B.Client)
 
-		// time.Sleep(time.Second * 2)
 		// 2 - Cause EigenDA to fail and ensure that the system falls back to anytrust in the presence of 503 eigenda-proxy errors
 		builder.L2.ConsensusNode.BatchPoster.SetEigenDAClientMock()
 		checkBatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(2000000000000), l2B.Client)

--- a/system_tests/eigenda_test.go
+++ b/system_tests/eigenda_test.go
@@ -247,7 +247,6 @@ func TestEigenDAProxyFailOverToAnyTrust(t *testing.T) {
 	Require(t, err)
 
 	builder.L2.ConsensusNode.BatchPoster.SetEigenDAWriter(eigenWriter)
-
 	checkEigenDABatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12*3), l2B.Client)
 
 	err = restServer.Shutdown()

--- a/system_tests/eigenda_test.go
+++ b/system_tests/eigenda_test.go
@@ -194,6 +194,7 @@ func TestEigenDAProxyFailOverToAnyTrust(t *testing.T) {
 	builder.nodeConfig.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
 	builder.nodeConfig.DataAvailability.ParentChainNodeURL = "none"
 
+	// set EigenDA params into L2 sequencer config
 	builder.nodeConfig.EigenDA.Enable = true
 	builder.nodeConfig.EigenDA.Rpc = proxyURL
 	builder.nodeConfig.BatchPoster.EnableEigenDAFailover = true
@@ -225,6 +226,7 @@ func TestEigenDAProxyFailOverToAnyTrust(t *testing.T) {
 	childNodeConfigB.EigenDA.Enable = true
 	childNodeConfigB.EigenDA.Rpc = proxyURL
 	childNodeConfigB.BatchPoster.EnableEigenDAFailover = true
+	childNodeConfigB.BatchPoster.CheckBatchCorrectness = true
 
 	nodeBParams := SecondNodeParams{
 		nodeConfig: childNodeConfigB,

--- a/system_tests/eigenda_test.go
+++ b/system_tests/eigenda_test.go
@@ -6,12 +6,19 @@ package arbtest
 import (
 	"context"
 	"math/big"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/offchainlabs/nitro/arbnode"
+	"github.com/offchainlabs/nitro/cmd/genericconf"
+	"github.com/offchainlabs/nitro/das"
+	"github.com/offchainlabs/nitro/eigenda"
+	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
+	"github.com/offchainlabs/nitro/util/headerreader"
 )
 
 const (
@@ -55,6 +62,196 @@ func TestEigenDAProxyBatchPosting(t *testing.T) {
 		builder.L2.cleanup()
 		cleanupB()
 	}
+}
+
+func TestEigenDAProxyFailOverToETHDA(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+	}()
+
+	// Setup L1 chain and contracts
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder.BuildL1(t)
+	// Setup DAS servers
+	l1NodeConfigB := arbnode.ConfigDefaultL1NonSequencerTest()
+
+	{
+
+		// Setup DAS config
+		builder.nodeConfig.EigenDA.Enable = true
+		builder.nodeConfig.EigenDA.Rpc = proxyURL
+		builder.nodeConfig.BatchPoster.EnableEigenDAFailover = true
+
+		// Setup L2 chain
+		builder.L2Info.GenerateAccount("User2")
+		builder.BuildL2OnL1(t)
+
+		// Setup second node
+		l1NodeConfigB.BlockValidator.Enable = false
+		l1NodeConfigB.EigenDA.Enable = true
+		l1NodeConfigB.EigenDA.Rpc = proxyURL
+		l1NodeConfigB.BatchPoster.EnableEigenDAFailover = true
+
+		nodeBParams := SecondNodeParams{
+			nodeConfig: l1NodeConfigB,
+			initData:   &builder.L2Info.ArbInitData,
+		}
+		l2B, cleanupB := builder.Build2ndNode(t, &nodeBParams)
+
+		// 1 - Ensure that batches can be submitted and read via EigenDA batch posting
+		checkEigenDABatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12), l2B.Client)
+
+		// time.Sleep(time.Second * 2)
+		// 2 - Cause EigenDA to fail and ensure that the system falls back to anytrust in the presence of 503 eigenda-proxy errors
+		builder.L2.ConsensusNode.BatchPoster.SetEigenDAClientMock()
+		checkBatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(2000000000000), l2B.Client)
+		// 3 - Emulate EigenDA becoming healthy again and ensure that the system starts using it for DA
+		eigenWriter, _ := eigenda.NewEigenDA(&eigenda.EigenDAConfig{
+			Enable: true,
+			Rpc:    proxyURL,
+		})
+
+		builder.L2.ConsensusNode.BatchPoster.SetEigenDAWriter(eigenWriter)
+
+		checkEigenDABatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(3000000000000), l2B.Client)
+		builder.L2.cleanup()
+		cleanupB()
+	}
+}
+
+func TestEigenDAProxyFailOverToAnyTrust(t *testing.T) {
+	initTest(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Setup L1 chain and contracts
+	builder := NewNodeBuilder(ctx).DefaultConfig(t, true)
+	builder.chainConfig = params.ArbitrumDevTestDASChainConfig()
+	builder.BuildL1(t)
+
+	arbSys, _ := precompilesgen.NewArbSys(types.ArbSysAddress, builder.L1.Client)
+	l1Reader, err := headerreader.New(ctx, builder.L1.Client, func() *headerreader.Config { return &headerreader.TestConfig }, arbSys)
+	Require(t, err)
+	l1Reader.Start(ctx)
+	defer l1Reader.StopAndWait()
+
+	keyDir, fileDataDir, dbDataDir := t.TempDir(), t.TempDir(), t.TempDir()
+	pubkey, _, err := das.GenerateAndStoreKeys(keyDir)
+	Require(t, err)
+
+	dbConfig := das.DefaultLocalDBStorageConfig
+	dbConfig.Enable = true
+	dbConfig.DataDir = dbDataDir
+
+	serverConfig := das.DataAvailabilityConfig{
+		Enable: true,
+
+		LocalCache: das.TestCacheConfig,
+
+		LocalFileStorage: das.LocalFileStorageConfig{
+			Enable:  true,
+			DataDir: fileDataDir,
+		},
+		LocalDBStorage: dbConfig,
+
+		Key: das.KeyConfig{
+			KeyDir: keyDir,
+		},
+
+		RequestTimeout: 5 * time.Second,
+		// L1NodeURL: normally we would have to set this but we are passing in the already constructed client and addresses to the factory
+	}
+
+	daReader, daWriter, signatureVerifier, daHealthChecker, lifecycleManager, err := das.CreateDAComponentsForDaserver(ctx, &serverConfig, l1Reader, &builder.addresses.SequencerInbox)
+	Require(t, err)
+	defer lifecycleManager.StopAndWaitUntil(time.Second)
+	rpcLis, err := net.Listen("tcp", "localhost:0")
+	Require(t, err)
+	_, err = das.StartDASRPCServerOnListener(ctx, rpcLis, genericconf.HTTPServerTimeoutConfigDefault, genericconf.HTTPServerBodyLimitDefault, daReader, daWriter, daHealthChecker, signatureVerifier)
+	Require(t, err)
+	restLis, err := net.Listen("tcp", "localhost:0")
+	Require(t, err)
+	restServer, err := das.NewRestfulDasServerOnListener(restLis, genericconf.HTTPServerTimeoutConfigDefault, daReader, daHealthChecker)
+	Require(t, err)
+
+	pubkeyA := pubkey
+	authorizeDASKeyset(t, ctx, pubkeyA, builder.L1Info, builder.L1.Client)
+
+	// Set AnyTrust params into L2 node config
+	builder.nodeConfig.DataAvailability = das.DataAvailabilityConfig{
+		Enable: true,
+
+		// AggregatorConfig set up below
+		RequestTimeout: 5 * time.Second,
+	}
+	beConfigA := das.BackendConfig{
+		URL:    "http://" + rpcLis.Addr().String(),
+		Pubkey: blsPubToBase64(pubkey),
+	}
+	builder.nodeConfig.DataAvailability.RPCAggregator = aggConfigForBackend(beConfigA)
+	builder.nodeConfig.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+	builder.nodeConfig.DataAvailability.RestAggregator.Enable = true
+	builder.nodeConfig.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
+	builder.nodeConfig.DataAvailability.ParentChainNodeURL = "none"
+
+	builder.nodeConfig.EigenDA.Enable = true
+	builder.nodeConfig.EigenDA.Rpc = proxyURL
+	builder.nodeConfig.BatchPoster.EnableEigenDAFailover = true
+
+	// Setup L2 chain
+	builder.L2Info = NewArbTestInfo(t, builder.chainConfig.ChainID)
+	builder.L2Info.GenerateAccount("User2")
+	cleanup := builder.BuildL2OnL1(t)
+
+	defer cleanup()
+
+	// Create node to sync from chain
+	childNodeConfigB := arbnode.ConfigDefaultL1NonSequencerTest().WithEigenDATestConfigParams()
+	childNodeConfigB.DataAvailability = das.DataAvailabilityConfig{
+		Enable: true,
+
+		// AggregatorConfig set up below
+
+		ParentChainNodeURL: "none",
+		RequestTimeout:     5 * time.Second,
+	}
+
+	childNodeConfigB.BlockValidator.Enable = false
+	childNodeConfigB.DataAvailability.Enable = true
+	childNodeConfigB.DataAvailability.RestAggregator = das.DefaultRestfulClientAggregatorConfig
+	childNodeConfigB.DataAvailability.RestAggregator.Enable = true
+	childNodeConfigB.DataAvailability.RestAggregator.Urls = []string{"http://" + restLis.Addr().String()}
+	childNodeConfigB.DataAvailability.ParentChainNodeURL = "none"
+	childNodeConfigB.EigenDA.Enable = true
+	childNodeConfigB.EigenDA.Rpc = proxyURL
+	childNodeConfigB.BatchPoster.EnableEigenDAFailover = true
+
+	nodeBParams := SecondNodeParams{
+		nodeConfig: childNodeConfigB,
+		initData:   &builder.L2Info.ArbInitData,
+	}
+	l2B, cleanupB := builder.Build2ndNode(t, &nodeBParams)
+	defer cleanupB()
+
+	// 1 - Ensure that batches can be submitted and read via EigenDA batch posting
+	checkEigenDABatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12), l2B.Client)
+	// 2 - Cause EigenDA to fail and ensure that the system falls back to anytrust in the presence of 503 eigenda-proxy errors
+	builder.L2.ConsensusNode.BatchPoster.SetEigenDAClientMock()
+	checkBatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12*2), l2B.Client)
+	// 3 - Emulate EigenDA becoming healthy again and ensure that the system starts using it for DA
+	eigenWriter, err := eigenda.NewEigenDA(&eigenda.EigenDAConfig{
+		Enable: true,
+		Rpc:    proxyURL,
+	})
+	Require(t, err)
+
+	builder.L2.ConsensusNode.BatchPoster.SetEigenDAWriter(eigenWriter)
+
+	checkEigenDABatchPosting(t, ctx, builder.L1.Client, builder.L2.Client, builder.L1Info, builder.L2Info, big.NewInt(1e12*3), l2B.Client)
+
+	err = restServer.Shutdown()
+	Require(t, err)
 }
 
 func checkEigenDABatchPosting(t *testing.T, ctx context.Context, l1client, l2clientA *ethclient.Client, l1info, l2info info, expectedBalance *big.Int, l2ClientsToCheck ...*ethclient.Client) {


### PR DESCRIPTION
**TLDR:** Added failover from ETH DA to EigenDA in the event of detected 503 or service unavailable errors. 

