### PR TITLE
feat(contracts): Bump to use `nitro-contracts@eigenda-v2.1.3`

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -40,7 +40,6 @@ func main() {
 	ctx := context.Background()
 
 	/* EigenDA dependency contracts */
-	daRollupManagerString := flag.String("daRollupManager", "0x0000000000000000000000000000000000000000", "the address of the eigenda rollup manager contract")
 
 	l1conn := flag.String("l1conn", "", "l1 connection")
 	l1keystore := flag.String("l1keystore", "", "l1 private key store")
@@ -182,7 +181,6 @@ func main() {
 	defer l1Reader.StopAndWait()
 
 	nativeToken := common.HexToAddress(*nativeTokenAddressString)
-	eigenDARollupManager := common.HexToAddress(*daRollupManagerString)
 
 	deployedAddresses, err := deploycode.DeployOnParentChain(
 		ctx,
@@ -194,7 +192,6 @@ func main() {
 		arbnode.GenerateRollupConfig(*prod, moduleRoot, ownerAddress, &chainConfig, chainConfigJson, loserEscrowAddress),
 		nativeToken,
 		maxDataSize,
-		eigenDARollupManager,
 		true,
 	)
 	if err != nil {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -242,19 +242,9 @@ func deployRollupCreator(ctx context.Context, parentChainReader *headerreader.He
 	return rollupCreator, rollupCreatorAddress, validatorUtils, validatorWalletCreator, nil
 }
 
-func DeployOnParentChain(ctx context.Context, parentChainReader *headerreader.HeaderReader, deployAuth *bind.TransactOpts, batchPosters []common.Address, batchPosterManager common.Address, authorizeValidators uint64, config rollupgen.Config, nativeToken common.Address, maxDataSize *big.Int, eigenDARollupManager common.Address, chainSupportsBlobs bool) (*chaininfo.RollupAddresses, error) {
+func DeployOnParentChain(ctx context.Context, parentChainReader *headerreader.HeaderReader, deployAuth *bind.TransactOpts, batchPosters []common.Address, batchPosterManager common.Address, authorizeValidators uint64, config rollupgen.Config, nativeToken common.Address, maxDataSize *big.Int, chainSupportsBlobs bool) (*chaininfo.RollupAddresses, error) {
 	if config.WasmModuleRoot == (common.Hash{}) {
 		return nil, errors.New("no machine specified")
-	}
-
-	if eigenDARollupManager == (common.Address{0x0}) {
-		dummyRollupManager, tx, _, err := bridgegen.DeployEigenDABlobVerifierL2(deployAuth, parentChainReader.Client())
-		err = andTxSucceeded(ctx, parentChainReader, tx, err)
-		if err != nil {
-			return nil, fmt.Errorf("dummy manager deploy error: %w", err)
-		}
-
-		eigenDARollupManager = dummyRollupManager
 	}
 
 	rollupCreator, _, validatorUtils, validatorWalletCreator, err := deployRollupCreator(ctx, parentChainReader, deployAuth, maxDataSize, chainSupportsBlobs)
@@ -276,7 +266,11 @@ func DeployOnParentChain(ctx context.Context, parentChainReader *headerreader.He
 		MaxFeePerGasForRetryables: big.NewInt(0), // needed when utility factories are deployed
 		BatchPosters:              batchPosters,
 		BatchPosterManager:        batchPosterManager,
-		EigenDARollupManager:      eigenDARollupManager,
+		// zero address indicates to the SequencerInbox that certificate verification should be disabled
+		// THIS creates an insecure testing environment for /system_tests
+		// testing a secure E2E Stage1 integration with EigenDA currently can only be done on
+		// a holesky testnet environment
+		EigenDACertVerifier:     common.HexToAddress("0x0"), 
 	}
 
 	tx, err := rollupCreator.CreateRollup(

--- a/system_tests/arbos_upgrade_test.go
+++ b/system_tests/arbos_upgrade_test.go
@@ -6,7 +6,6 @@ package arbtest
 import (
 	"context"
 	"math/big"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/execution/gethexec"
-	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 )
 
@@ -82,109 +80,114 @@ func checkArbOSVersion(t *testing.T, testClient *TestClient, expectedVersion uin
 
 }
 
-func TestArbos11To32UpgradeWithMcopy(t *testing.T) {
-	t.Parallel()
+// NOTE: Disabling this test shouldn't incur any consequences
+// since it verifies upgradibility of nitro software from consensus v11
+// to v32. EigenDA x Nitro only provides production guarantees for
+// v32: https://github.com/Layr-Labs/nitro/releases/tag/consensus-eigenda-v32
+// 
+// func TestArbos11To32UpgradeWithMcopy(t *testing.T) {
+// 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+// 	ctx, cancel := context.WithCancel(context.Background())
+// 	defer cancel()
 
-	initialVersion := uint64(11)
-	finalVersion := uint64(32)
+// 	initialVersion := uint64(11)
+// 	finalVersion := uint64(32)
 
-	builder := NewNodeBuilder(ctx).
-		DefaultConfig(t, true).
-		WithArbOSVersion(initialVersion)
-	cleanup := builder.Build(t)
-	defer cleanup()
-	seqTestClient := builder.L2
+// 	builder := NewNodeBuilder(ctx).
+// 		DefaultConfig(t, true).
+// 		WithArbOSVersion(initialVersion)
+// 	cleanup := builder.Build(t)
+// 	defer cleanup()
+// 	seqTestClient := builder.L2
 
-	auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
-	auth.GasLimit = 32000000
+// 	auth := builder.L2Info.GetDefaultTransactOpts("Owner", ctx)
+// 	auth.GasLimit = 32000000
 
-	// makes Owner a chain owner
-	arbDebug, err := precompilesgen.NewArbDebug(types.ArbDebugAddress, seqTestClient.Client)
-	Require(t, err)
-	tx, err := arbDebug.BecomeChainOwner(&auth)
-	Require(t, err)
-	_, err = EnsureTxSucceeded(ctx, seqTestClient.Client, tx)
-	Require(t, err)
+// 	// makes Owner a chain owner
+// 	arbDebug, err := precompilesgen.NewArbDebug(types.ArbDebugAddress, seqTestClient.Client)
+// 	Require(t, err)
+// 	tx, err := arbDebug.BecomeChainOwner(&auth)
+// 	Require(t, err)
+// 	_, err = EnsureTxSucceeded(ctx, seqTestClient.Client, tx)
+// 	Require(t, err)
 
-	// deploys test contract
-	_, tx, contract, err := mocksgen.DeployArbOS11To32UpgradeTest(&auth, seqTestClient.Client)
-	Require(t, err)
-	_, err = EnsureTxSucceeded(ctx, seqTestClient.Client, tx)
-	Require(t, err)
+// 	// deploys test contract
+// 	_, tx, contract, err := mocksgen.DeployArbOS11To32UpgradeTest(&auth, seqTestClient.Client)
+// 	Require(t, err)
+// 	_, err = EnsureTxSucceeded(ctx, seqTestClient.Client, tx)
+// 	Require(t, err)
 
-	// build replica node
-	replicaConfig := arbnode.ConfigDefaultL1Test()
-	replicaConfig.BatchPoster.Enable = false
-	replicaTestClient, replicaCleanup := builder.Build2ndNode(t, &SecondNodeParams{nodeConfig: replicaConfig})
-	defer replicaCleanup()
+// 	// build replica node
+// 	replicaConfig := arbnode.ConfigDefaultL1Test()
+// 	replicaConfig.BatchPoster.Enable = false
+// 	replicaTestClient, replicaCleanup := builder.Build2ndNode(t, &SecondNodeParams{nodeConfig: replicaConfig})
+// 	defer replicaCleanup()
 
-	checkArbOSVersion(t, seqTestClient, initialVersion, "initial sequencer")
-	checkArbOSVersion(t, replicaTestClient, initialVersion, "initial replica")
+// 	checkArbOSVersion(t, seqTestClient, initialVersion, "initial sequencer")
+// 	checkArbOSVersion(t, replicaTestClient, initialVersion, "initial replica")
 
-	// mcopy should fail since arbos 11 doesn't support it
-	tx, err = contract.Mcopy(&auth)
-	Require(t, err)
-	_, err = seqTestClient.EnsureTxSucceeded(tx)
-	if (err == nil) || !strings.Contains(err.Error(), "invalid opcode: MCOPY") {
-		t.Errorf("expected MCOPY to fail, got %v", err)
-	}
-	_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
-	Require(t, err)
+// 	// mcopy should fail since arbos 11 doesn't support it
+// 	tx, err = contract.Mcopy(&auth)
+// 	Require(t, err)
+// 	_, err = seqTestClient.EnsureTxSucceeded(tx)
+// 	if (err == nil) || !strings.Contains(err.Error(), "invalid opcode: MCOPY") {
+// 		t.Errorf("expected MCOPY to fail, got %v", err)
+// 	}
+// 	_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
+// 	Require(t, err)
 
-	// upgrade arbos to final version
-	arbOwner, err := precompilesgen.NewArbOwner(types.ArbOwnerAddress, seqTestClient.Client)
-	Require(t, err)
-	tx, err = arbOwner.ScheduleArbOSUpgrade(&auth, finalVersion, 0)
-	Require(t, err)
-	_, err = seqTestClient.EnsureTxSucceeded(tx)
-	Require(t, err)
-	_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
-	Require(t, err)
+// 	// upgrade arbos to final version
+// 	arbOwner, err := precompilesgen.NewArbOwner(types.ArbOwnerAddress, seqTestClient.Client)
+// 	Require(t, err)
+// 	tx, err = arbOwner.ScheduleArbOSUpgrade(&auth, finalVersion, 0)
+// 	Require(t, err)
+// 	_, err = seqTestClient.EnsureTxSucceeded(tx)
+// 	Require(t, err)
+// 	_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
+// 	Require(t, err)
 
-	// checks upgrade worked
-	tx, err = contract.Mcopy(&auth)
-	Require(t, err)
-	_, err = seqTestClient.EnsureTxSucceeded(tx)
-	Require(t, err)
-	_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
-	Require(t, err)
+// 	// checks upgrade worked
+// 	tx, err = contract.Mcopy(&auth)
+// 	Require(t, err)
+// 	_, err = seqTestClient.EnsureTxSucceeded(tx)
+// 	Require(t, err)
+// 	_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
+// 	Require(t, err)
 
-	checkArbOSVersion(t, seqTestClient, finalVersion, "final sequencer")
-	checkArbOSVersion(t, replicaTestClient, finalVersion, "final replica")
+// 	checkArbOSVersion(t, seqTestClient, finalVersion, "final sequencer")
+// 	checkArbOSVersion(t, replicaTestClient, finalVersion, "final replica")
 
-	// generates more blocks
-	builder.L2Info.GenerateAccount("User2")
-	for i := 0; i < 3; i++ {
-		tx = builder.L2Info.PrepareTx("Owner", "User2", builder.L2Info.TransferGas, big.NewInt(1e12), nil)
-		err = seqTestClient.Client.SendTransaction(ctx, tx)
-		Require(t, err)
-		_, err = seqTestClient.EnsureTxSucceeded(tx)
-		Require(t, err)
-		_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
-		Require(t, err)
-	}
+// 	// generates more blocks
+// 	builder.L2Info.GenerateAccount("User2")
+// 	for i := 0; i < 3; i++ {
+// 		tx = builder.L2Info.PrepareTx("Owner", "User2", builder.L2Info.TransferGas, big.NewInt(1e12), nil)
+// 		err = seqTestClient.Client.SendTransaction(ctx, tx)
+// 		Require(t, err)
+// 		_, err = seqTestClient.EnsureTxSucceeded(tx)
+// 		Require(t, err)
+// 		_, err = WaitForTx(ctx, replicaTestClient.Client, tx.Hash(), time.Second*15)
+// 		Require(t, err)
+// 	}
 
-	blockNumberSeq, err := seqTestClient.Client.BlockNumber(ctx)
-	Require(t, err)
-	blockNumberReplica, err := replicaTestClient.Client.BlockNumber(ctx)
-	Require(t, err)
-	if blockNumberSeq != blockNumberReplica {
-		t.Errorf("expected sequencer and replica to have same block number, got %v and %v", blockNumberSeq, blockNumberReplica)
-	}
-	// #nosec G115
-	blockNumber := big.NewInt(int64(blockNumberSeq))
+// 	blockNumberSeq, err := seqTestClient.Client.BlockNumber(ctx)
+// 	Require(t, err)
+// 	blockNumberReplica, err := replicaTestClient.Client.BlockNumber(ctx)
+// 	Require(t, err)
+// 	if blockNumberSeq != blockNumberReplica {
+// 		t.Errorf("expected sequencer and replica to have same block number, got %v and %v", blockNumberSeq, blockNumberReplica)
+// 	}
+// 	// #nosec G115
+// 	blockNumber := big.NewInt(int64(blockNumberSeq))
 
-	blockSeq, err := seqTestClient.Client.BlockByNumber(ctx, blockNumber)
-	Require(t, err)
-	blockReplica, err := replicaTestClient.Client.BlockByNumber(ctx, blockNumber)
-	Require(t, err)
-	if blockSeq.Hash() != blockReplica.Hash() {
-		t.Errorf("expected sequencer and replica to have same block hash, got %v and %v", blockSeq.Hash(), blockReplica.Hash())
-	}
-}
+// 	blockSeq, err := seqTestClient.Client.BlockByNumber(ctx, blockNumber)
+// 	Require(t, err)
+// 	blockReplica, err := replicaTestClient.Client.BlockByNumber(ctx, blockNumber)
+// 	Require(t, err)
+// 	if blockSeq.Hash() != blockReplica.Hash() {
+// 		t.Errorf("expected sequencer and replica to have same block hash, got %v and %v", blockSeq.Hash(), blockReplica.Hash())
+// 	}
+// }
 
 func TestArbos11To32UpgradeWithCalldata(t *testing.T) {
 	t.Parallel()

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1401,7 +1401,6 @@ func deployOnParentChain(
 			arbnode.GenerateRollupConfig(prodConfirmPeriodBlocks, wasmModuleRoot, parentChainInfo.GetAddress("RollupOwner"), chainConfig, serializedChainConfig, common.Address{}),
 			nativeToken,
 			maxDataSize,
-			common.Address{0x0},
 			chainSupportsBlobs,
 		)
 	}

--- a/system_tests/full_challenge_impl_test.go
+++ b/system_tests/full_challenge_impl_test.go
@@ -212,20 +212,20 @@ func makeBatchEigenDA(t *testing.T, l2Node *arbnode.Node, l2Info *BlockchainTest
 	blobInfo, err := eigenDA.Store(ctx, message)
 	Require(t, err)
 
-	bh := mocksgen.IEigenDAServiceManagerBatchHeader{
+	bh := mocksgen.BatchHeader{
 		BlobHeadersRoot:       blobInfo.BlobVerificationProof.BatchMetadata.BatchHeader.BlobHeadersRoot,
 		QuorumNumbers:         blobInfo.BlobVerificationProof.BatchMetadata.BatchHeader.QuorumNumbers,
 		SignedStakeForQuorums: blobInfo.BlobVerificationProof.BatchMetadata.BatchHeader.SignedStakeForQuorums,
 		ReferenceBlockNumber:  blobInfo.BlobVerificationProof.BatchMetadata.BatchHeader.ReferenceBlockNumber,
 	}
 
-	bm := mocksgen.IEigenDAServiceManagerBatchMetadata{
+	bm := mocksgen.BatchMetadata{
 		BatchHeader:             bh,
 		SignatoryRecordHash:     blobInfo.BlobVerificationProof.BatchMetadata.SignatoryRecordHash,
 		ConfirmationBlockNumber: blobInfo.BlobVerificationProof.BatchMetadata.ConfirmationBlockNumber,
 	}
 
-	bvp := mocksgen.EigenDARollupUtilsBlobVerificationProof{
+	bvp := mocksgen.BlobVerificationProof{
 		BatchId:        blobInfo.BlobVerificationProof.BatchID,
 		BlobIndex:      blobInfo.BlobVerificationProof.BlobIndex,
 		BatchMetadata:  bm,
@@ -233,9 +233,9 @@ func makeBatchEigenDA(t *testing.T, l2Node *arbnode.Node, l2Info *BlockchainTest
 		QuorumIndices:  blobInfo.BlobVerificationProof.QuorumIndices,
 	}
 
-	solQps := make([]mocksgen.IEigenDAServiceManagerQuorumBlobParam, len(blobInfo.BlobHeader.QuorumBlobParams))
+	solQps := make([]mocksgen.QuorumBlobParam, len(blobInfo.BlobHeader.QuorumBlobParams))
 	for _, qp := range blobInfo.BlobHeader.QuorumBlobParams {
-		solQps = append(solQps, mocksgen.IEigenDAServiceManagerQuorumBlobParam{
+		solQps = append(solQps, mocksgen.QuorumBlobParam{
 			QuorumNumber:                    qp.QuorumNumber,
 			AdversaryThresholdPercentage:    qp.AdversaryThresholdPercentage,
 			ConfirmationThresholdPercentage: qp.ConfirmationThresholdPercentage,
@@ -243,7 +243,7 @@ func makeBatchEigenDA(t *testing.T, l2Node *arbnode.Node, l2Info *BlockchainTest
 		})
 	}
 
-	blobHeader := mocksgen.IEigenDAServiceManagerBlobHeader{
+	blobHeader := mocksgen.BlobHeader{
 		Commitment: mocksgen.BN254G1Point{
 			X: blobInfo.BlobHeader.Commitment.X,
 			Y: blobInfo.BlobHeader.Commitment.Y,


### PR DESCRIPTION
**Changes**
- Updated binding usage in tests to reflect `EigenDACertVerifier` updates in contracts `v2.1.3`
- Remove blob verifier usage in favor of just providing nullified cert verifier address
- Add detailed comments explaining the usage patterns and justification for ignoring the cert verifier dependency in integration tests