### PR TITLE
fix(eigenda): Prefix zero bytes if data commitment fields are less after serializing from big int

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -284,6 +284,8 @@ COPY --from=node-builder /workspace/target/bin/prover /usr/local/bin/
 COPY --from=node-builder /workspace/target/bin/dbconv /usr/local/bin/
 COPY ./scripts/convert-databases.bash /usr/local/bin/
 COPY --from=machine-versions /workspace/machines /home/user/target/machines
+## Load EigenDA BN254 SRS trusted setup values
+COPY --from=wasm-libs-builder /workspace/arbitrator/prover/src/mainnet-files/ /home/user/arbitrator/prover/src/mainnet-files/
 COPY ./scripts/validate-wasm-module-root.sh .
 RUN ./validate-wasm-module-root.sh /home/user/target/machines /usr/local/bin/prover
 USER root
@@ -336,8 +338,7 @@ FROM nitro-node AS nitro-node-validator
 USER root
 COPY --from=nitro-legacy /usr/local/bin/nitro-val /home/user/nitro-legacy/bin/nitro-val
 COPY --from=nitro-legacy /usr/local/bin/jit /home/user/nitro-legacy/bin/jit
-## Load EigenDA BN254 SRS values
-COPY --from=wasm-libs-builder /workspace/arbitrator/prover/src/mainnet-files/ /home/user/arbitrator/prover/src/mainnet-files/
+
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -208,7 +208,7 @@ RUN apt-get update && apt-get install -y unzip wget curl
 WORKDIR /workspace/machines
 
 # Download WAVM machines
-# no fetch since these replay artifacts are only used for backwards compatibility for Arbitrum One and Nova
+# no fetch since these replay artifacts are only used for backwards compatibility for vanilla Arbitrum One and Nova
 COPY ./scripts/download-machine.sh .
 COPY ./scripts/download-machine-eigenda.sh .
 #RUN ./download-machine.sh consensus-v1-rc1 0xbb9d58e9527566138b682f3a207c0976d5359837f6e330f4017434cca983ff41
@@ -233,6 +233,7 @@ COPY ./scripts/download-machine-eigenda.sh .
 # RUN ./download-machine.sh consensus-v31 0x260f5fa5c3176a856893642e149cf128b5a8de9f828afec8d11184415dd8dc69
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32 0x951009942c00b5bd0abec233174fe33fadf7cd5013d17b042f9b28b3b00b469c
+RUN ./download-machine-eigenda.sh consensus-eigenda-v32.1 0x04a297cdd13254c4c6c26388915d416286daf22f3a20e3ebee10400a3129dd17
 
 FROM golang:1.23.1-bookworm AS node-builder
 WORKDIR /workspace

--- a/eigenda/certificate.go
+++ b/eigenda/certificate.go
@@ -102,27 +102,27 @@ func (e *EigenDAV1Cert) ToDisperserBlobInfo() (*disperser.BlobInfo, error) {
 	xBytes := e.BlobHeader.Commitment.X.Bytes()
 	yBytes := e.BlobHeader.Commitment.Y.Bytes()
 
-	// Remove 0 byte padding (if applicable)
+	// Remove 0x0 byte padding or add (if applicable)
 	// Sometimes the big.Int --> bytes transformation would result in a byte array with an
-	// extra 0x0 prefixed byte which changes the cert representation returned from /put/
+	// extra or missing 0x0 prefix byte which changes the cert representation returned from /put/
 	// on eigenda-proxy since the commitment coordinates returned from the disperser are always
 	// 32 bytes each. If the prefixes are kept then secondary storage lookups would fail on the proxy!
 
-	parsedX, err := removeZeroPadding32Bytes(xBytes)
+	parsedX, err := stripZeroPrefixAndEnsure32Bytes(xBytes)
 	if err != nil {
 		log.Error(`
 		failed to remove 0x0 bytes from v1 certificate commitment x field.
 		This cert may fail if referenced as lookup key for secondary storage targets on eigenda-proxy.
-	`)
+	`, "error", err)
 		parsedX = xBytes
 	}
 
-	parsedY, err := removeZeroPadding32Bytes(yBytes)
+	parsedY, err := stripZeroPrefixAndEnsure32Bytes(yBytes)
 	if err != nil {
 		log.Error(`
 		failed to remove 0x0 bytes from v1 certificate commitment y field.
 		This cert may fail if referenced as lookup key for secondary storage targets on eigenda-proxy.
-	`)
+	`, "error", err)
 		parsedY = yBytes
 	}
 

--- a/eigenda/serialize.go
+++ b/eigenda/serialize.go
@@ -107,11 +107,13 @@ func padPow2(data []byte) ([]byte, error) {
 	return rs.ToByteArray(paddedDataFr, dataFrLenPow2*encoding.BYTES_PER_SYMBOL), nil
 }
 
-// removeZeroPadding32Bytes removes any prefix padded zero bytes from an assumed
-// 32 byte value
-func removeZeroPadding32Bytes(arr []byte) ([]byte, error) {
+// stripZeroPrefixAndEnsure32Bytes removes any prefix padded zero bytes from an assumed
+// 32 byte value and pads zero prefix bytes if value size < 32
+func stripZeroPrefixAndEnsure32Bytes(arr []byte) ([]byte, error) {
 	if len(arr) < 32 {
-		return nil, fmt.Errorf("expected value >= 32 bytes; got %d", len(arr))
+		// pad zeros to preserve value at exactly 32 bytes
+		zeroBuffer := make([]byte, 32 - len(arr))
+		return append(zeroBuffer, arr...), nil
 	}
 
 	// iterate over prefix bytes and verify only zero's are included

--- a/eigenda/serialize_test.go
+++ b/eigenda/serialize_test.go
@@ -23,14 +23,14 @@ func Test_EncodeDecodeBlob(t *testing.T) {
 	}
 }
 
-func Test_RemoveZeroPadding32Bytes(t *testing.T) {
+func Test_StripZeroPrefixAndEnsure32Bytes(t *testing.T) {
 	testArr := make([]byte, 32)
 	for i := range 32 {
 		testArr[i] = byte(i)
 	}
 
 	// 1 - do nothing
-	out1, err := removeZeroPadding32Bytes(testArr)
+	out1, err := stripZeroPrefixAndEnsure32Bytes(testArr)
 	if err != nil {
 		t.Fatalf("failed to sanitize bytes to field element: %v", testArr)
 	}
@@ -42,7 +42,7 @@ func Test_RemoveZeroPadding32Bytes(t *testing.T) {
 	// 2 - add padding and ensure its been removed
 	testArr = append([]byte{0x0, 0x0, 0x0}, testArr...)
 
-	out2, err := removeZeroPadding32Bytes(testArr)
+	out2, err := stripZeroPrefixAndEnsure32Bytes(testArr)
 
 	if !bytes.Equal(out1, out2) {
 		t.Fatalf("not equal; in %v, out %v", out1, out2)
@@ -52,15 +52,19 @@ func Test_RemoveZeroPadding32Bytes(t *testing.T) {
 
 	testArr = append([]byte{0x69}, testArr...)
 
-	_, err = removeZeroPadding32Bytes(testArr)
+	_, err = stripZeroPrefixAndEnsure32Bytes(testArr)
 	if err == nil {
 		t.Fatalf("expected error: %v", err)
 	}
 
-	// 4 - ensure error when input too small
+	// 4 - ensure padding when input too small
 
-	_, err = removeZeroPadding32Bytes([]byte{0x42})
-	if err == nil {
+	out3, err := stripZeroPrefixAndEnsure32Bytes([]byte{0x42})
+	if err != nil {
 		t.Fatalf("expected error: %v", err)
+	}
+
+	if out3[31] != 0x42 {
+		t.Fatalf("expected 0x42 as last value in 32 byte arr")
 	}
 }


### PR DESCRIPTION
- Fix big int serialization bug by prepending 0x0 bytes if length > 32
- Update dockerfile to fetch latest consensus machine artifact: https://github.com/Layr-Labs/nitro/releases/tag/consensus-eigenda-v32.1 