### PR TITLE
chore: Fix docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,6 +65,9 @@ jobs:
           cd nitro-testnode
           ./test-node.bash --init --dev &
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        
       - name: Wait for rpc to come up
         shell: bash
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   docker:
     name: Docker build
-    runs-on: linux-2xl
+    runs-on: ubuntu-latest
     services:
       # local registery
       registry:
@@ -65,8 +65,8 @@ jobs:
           cd nitro-testnode
           ./test-node.bash --init --dev &
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
         
       - name: Wait for rpc to come up
         shell: bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   docker:
     name: Docker build
-    runs-on: ubuntu-latest
+    runs-on: linux-2xl
     services:
       # local registery
       registry:
@@ -64,9 +64,6 @@ jobs:
         run: |
           cd nitro-testnode
           ./test-node.bash --init --dev &
-
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
         
       - name: Wait for rpc to come up
         shell: bash


### PR DESCRIPTION
Turns out testnode was using latest foundry versions for `rollupcreator` and `boldupgrader` which was causing build issues in CI env. Testnode PR is [here](https://github.com/Layr-Labs/nitro-testnode/pull/25)