### PR TITLE
fix: remove seqInboxMaxDataSize > nodeConfig.Node.BatchPoster.MaxSize check when EigenDA is enabled

### DIFF
--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -578,7 +578,7 @@ func mainImpl() int {
 	}
 	// If batchPoster is enabled, validate MaxSize to be at least 10kB below the sequencer inbox’s maxDataSize if the data availability service is not enabled.
 	// The 10kB gap is because its possible for the batch poster to exceed its MaxSize limit and produce batches of slightly larger size.
-	if nodeConfig.Node.BatchPoster.Enable && !nodeConfig.Node.DataAvailability.Enable {
+	if nodeConfig.Node.BatchPoster.Enable && (!nodeConfig.Node.DataAvailability.Enable || !nodeConfig.Node.EigenDA.Enable) {
 		if nodeConfig.Node.BatchPoster.MaxSize > seqInboxMaxDataSize-10000 {
 			log.Error("batchPoster's MaxSize is too large")
 			return 1


### PR DESCRIPTION
The check on `seqInboxMaxDataSize` is not relevant if eigen DA is enabled, similar to how it's not relevant if another DA (e.g. anytrust) is enabled, since we're not posting txs to the calldata of the sequencer inbox anymore. This change has been tested by spinning up a rollup, confirming:
- A config with a raised max tx data size passes validation.
- A tx with larger data size can be sent successfully.
