### PR TITLE
chore: Add Consensus V32.2 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ COPY ./scripts/download-machine-eigenda.sh .
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32 0x951009942c00b5bd0abec233174fe33fadf7cd5013d17b042f9b28b3b00b469c
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32.1 0x04a297cdd13254c4c6c26388915d416286daf22f3a20e3ebee10400a3129dd17
-RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e
+RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0x52366dee0842a0312d8528dabc00f47c79b3845d4fb889147f8a68c5ea732ccb
 FROM golang:1.23.1-bookworm AS node-builder
 WORKDIR /workspace
 ARG version=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ COPY ./scripts/download-machine-eigenda.sh .
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32 0x951009942c00b5bd0abec233174fe33fadf7cd5013d17b042f9b28b3b00b469c
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32.1 0x04a297cdd13254c4c6c26388915d416286daf22f3a20e3ebee10400a3129dd17
-
+RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e
 FROM golang:1.23.1-bookworm AS node-builder
 WORKDIR /workspace
 ARG version=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ COPY ./scripts/download-machine-eigenda.sh .
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32 0x951009942c00b5bd0abec233174fe33fadf7cd5013d17b042f9b28b3b00b469c
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32.1 0x04a297cdd13254c4c6c26388915d416286daf22f3a20e3ebee10400a3129dd17
-RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0x52366dee0842a0312d8528dabc00f47c79b3845d4fb889147f8a68c5ea732ccb
+RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e
 FROM golang:1.23.1-bookworm AS node-builder
 WORKDIR /workspace
 ARG version=""


### PR DESCRIPTION
Adds consensus v32.2 artifact download as step within `Dockerfile`

Logs from local run:
```
validator-1  | INFO [07-14|06:51:16.088] EigenDA enabled                          failover=true anytrust=true
0000000\",\"input\":\"0x4b678a66\",\"to\":\"0xfaefd51010919ed44982d1c3a2133e2761dc8c67\"}, \"latest\"]" errorData="\"0x\""
poster-1     | INFO [07-14|06:51:36.180] Dispersing batch as blob to EigenDA      dataLength=6632
validator-1  | WARN [07-14|06:51:36.210] validator address isn't whitelisted      address=<nil> txSender=0x6A568afe0f82d34759347bb36F14A6bB171d2CBe
poster-1     | INFO [07-14|06:51:36.213] DataPoster sent transaction              nonce=0 hash=26bd63..135377 feeCap=12,000,000,080 tipCap=1,200,000,000 blobFeeCap=<nil> gas=174,891
poster-1     | INFO [07-14|06:51:36.214] BatchPoster: batch sent                  eigenDA=true 4844=false sequenceNumber=1 from=1 to=16 prevDelayed=1 currentDelayed=10 totalSegments=21 numBlobs=0
validator-1  | INFO [07-14|06:51:37.080] Reading blob from EigenDA                batchID=69
sequencer-1  | INFO [07-14|06:51:37.081] Reading blob from EigenDA                batchID=69
poster-1     | INFO [07-14|06:51:37.080] Reading blob from EigenDA                batchID=69
validator-1  | INFO [07-14|06:51:37.096] InboxTracker                             sequencerBatchCount=2 messageCount=16 l1Block=179 l1Timestamp=2025-07-14T06:51:14+0000
validator-1  | INFO [07-14|06:51:37.099] Indexed transactions                     blocks=2 txs=3 tail=0 elapsed="130.667µs"
validator-1  | INFO [07-14|06:51:37.100] created block                            l2Block=1 l2BlockHash=b03596..18edee
sequencer-1  | INFO [07-14|06:51:37.104] InboxTracker                             sequencerBatchCount=2 messageCount=16 l1Block=179 l1Timestamp=2025-07-14T06:51:14+0000
poster-1     | INFO [07-14|06:51:37.104] InboxTracker                             sequencerBatchCount=2 messageCount=16 l1Block=179 l1Timestamp=2025-07-14T06:51:14+0000
validator-1  | INFO [07-14|06:51:37.259] Reading blob from EigenDA                batchID=69
validator-1  | INFO [07-14|06:51:38.101] created block                            l2Block=15 l2BlockHash=2e632d..2c08dd
validator-1  | INFO [07-14|06:51:41.270] validated execution                      messageCount=3  globalstate="BlockHash: 0x606813c438c731586785b91bc4da6933cc4897ca92b379e9dc757c6615cd45a5, SendRoot: 0x0000000000000000000000000000000000000000000000000000000000000000, Batch: 1, PosInBatch: 2" WasmRoots=[0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e]
validator-1  | INFO [07-14|06:51:42.275] validated execution                      messageCount=16 globalstate="BlockHash: 0x2e632da03cc2be89f7f49484dc221328c9c7aa1a3669654193cb9bfc7e2c08dd, SendRoot: 0x0000000000000000000000000000000000000000000000000000000000000000, Batch: 2, PosInBatch: 0" WasmRoots=[0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e]
```