### PR TITLE
fix: hasbits check

### DIFF
--- a/arbstate/daprovider/util.go
+++ b/arbstate/daprovider/util.go
@@ -101,7 +101,7 @@ func hasBits(checking byte, bits byte) bool {
 	// from other dapReaders and cause terminal errors since an EigenDA message type
 	// would be passed into e.g an AnyTrust reader
 	// assuming 0xed for the message header byte is a fundamental design flaw
-	if bits == EigenDAMessageHeaderFlag && checking != EigenDAMessageHeaderFlag {
+	if checking == EigenDAMessageHeaderFlag && bits != EigenDAMessageHeaderFlag {
 		return false
 	}
 

--- a/arbstate/daprovider/util_test.go
+++ b/arbstate/daprovider/util_test.go
@@ -1,0 +1,29 @@
+package daprovider
+
+import "testing"
+
+func Test_EigenDAHeaderByte(t *testing.T) {
+	if IsL1AuthenticatedMessageHeaderByte(EigenDAMessageHeaderFlag) {
+		t.Error("Expected EigenDAMessageHeaderFlag to not be a valid L1 authenticated message header byte")
+	}
+
+	if IsDASMessageHeaderByte(EigenDAMessageHeaderFlag) {
+		t.Error("Expected EigenDAMessageHeaderFlag to not be a valid DAS message header byte")
+	}
+
+	if IsTreeDASMessageHeaderByte(EigenDAMessageHeaderFlag) {
+		t.Error("Expected EigenDAMessageHeaderFlag to not be a valid Tree DAS message header byte")
+	}
+
+	if IsZeroheavyEncodedHeaderByte(EigenDAMessageHeaderFlag) {
+		t.Error("Expected EigenDAMessageHeaderFlag to not be a valid Zeroheavy encoded header byte")
+	}
+
+	if IsBlobHashesHeaderByte(EigenDAMessageHeaderFlag) {
+		t.Error("Expected EigenDAMessageHeaderFlag to not be a valid Blob hashes header byte")
+	}
+
+	if IsBrotliMessageHeaderByte(EigenDAMessageHeaderFlag) {
+		t.Error("Expected EigenDAMessageHeaderFlag to not be a valid Brotli message header byte")
+	}
+}


### PR DESCRIPTION
me being an idiot I reverted the order of the `hasBits` which was yielding false. this was undetectable in local testing since we updated dapReader ordering in https://github.com/Layr-Labs/nitro/pull/99 which would bake `eigenDAReader` first. 