### PR TITLE
chore: Move EigenDA message logic to daprovider package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ COPY ./scripts/download-machine-eigenda.sh .
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32 0x951009942c00b5bd0abec233174fe33fadf7cd5013d17b042f9b28b3b00b469c
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32.1 0x04a297cdd13254c4c6c26388915d416286daf22f3a20e3ebee10400a3129dd17
-RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e
+RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0x8da5648e4bcd42306affd60f5fe99c3837da38f11a849bc6bd40b7896974ed09
 FROM golang:1.23.1-bookworm AS node-builder
 WORKDIR /workspace
 ARG version=""

--- a/arbstate/daprovider/util.go
+++ b/arbstate/daprovider/util.go
@@ -108,6 +108,10 @@ func hasBits(checking byte, bits byte) bool {
 	return (checking & bits) == bits
 }
 
+func IsEigenDAMessageHeaderByte(header byte) bool {
+	return hasBits(header, EigenDAMessageHeaderFlag)
+}
+
 func IsL1AuthenticatedMessageHeaderByte(header byte) bool {
 	return hasBits(header, L1AuthenticatedMessageHeaderFlag)
 }

--- a/arbstate/daprovider/util_test.go
+++ b/arbstate/daprovider/util_test.go
@@ -1,6 +1,8 @@
 package daprovider
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_EigenDAHeaderByte(t *testing.T) {
 	if IsL1AuthenticatedMessageHeaderByte(EigenDAMessageHeaderFlag) {
@@ -25,5 +27,35 @@ func Test_EigenDAHeaderByte(t *testing.T) {
 
 	if IsBrotliMessageHeaderByte(EigenDAMessageHeaderFlag) {
 		t.Error("Expected EigenDAMessageHeaderFlag to not be a valid Brotli message header byte")
+	}
+}
+
+func Test_HeaderByteCheck(t *testing.T) {
+	if !IsL1AuthenticatedMessageHeaderByte(L1AuthenticatedMessageHeaderFlag) {
+		t.Error("Expected L1AuthenticatedMessageHeaderFlag to be a valid L1 authenticated message header byte")
+	}
+
+	if !IsDASMessageHeaderByte(DASMessageHeaderFlag) {
+		t.Error("Expected DASMessageHeaderFlag to be a valid DAS message header byte")
+	}
+
+	if !IsTreeDASMessageHeaderByte(TreeDASMessageHeaderFlag) {
+		t.Error("Expected TreeDASMessageHeaderFlag to be a valid Tree DAS message header byte")
+	}
+
+	if !IsZeroheavyEncodedHeaderByte(ZeroheavyMessageHeaderFlag) {
+		t.Error("Expected ZeroheavyMessageHeaderFlag to be a valid Zeroheavy encoded header byte")
+	}
+
+	if !IsBlobHashesHeaderByte(BlobHashesHeaderFlag) {
+		t.Error("Expected BlobHashesHeaderFlag to be a valid Blob hashes header byte")
+	}
+
+	if !IsBrotliMessageHeaderByte(BrotliMessageHeaderByte) {
+		t.Error("Expected BrotliMessageHeaderByte to be a valid Brotli message header byte")
+	}
+
+	if !IsEigenDAMessageHeaderByte(EigenDAMessageHeaderFlag) {
+		t.Error("Expected EigenDAMessageHeaderFlag to be a valid EigenDA message header byte")
 	}
 }

--- a/eigenda/eigenda.go
+++ b/eigenda/eigenda.go
@@ -6,22 +6,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/offchainlabs/nitro/arbstate/daprovider"
 )
 
 const (
 	sequencerMsgOffset = 41
 	MaxBatchSize       = 16_252_897 // largest blob size allowed before payload -> blob padding to 16MiB
 )
-
-func IsEigenDAMessageHeaderByte(header byte) bool {
-	return hasBits(header, daprovider.EigenDAMessageHeaderFlag)
-}
-
-// hasBits returns true if `checking` has all `bits`
-func hasBits(checking byte, bits byte) bool {
-	return (checking & bits) == bits
-}
 
 type EigenDAWriter interface {
 	Store(context.Context, []byte) (*EigenDAV1Cert, error)

--- a/eigenda/reader.go
+++ b/eigenda/reader.go
@@ -20,7 +20,7 @@ type readerForEigenDA struct {
 }
 
 func (d *readerForEigenDA) IsValidHeaderByte(headerByte byte) bool {
-	return IsEigenDAMessageHeaderByte(headerByte)
+	return daprovider.IsEigenDAMessageHeaderByte(headerByte)
 }
 
 func (d *readerForEigenDA) RecoverPayloadFromBatch(

--- a/system_tests/eigenda_test.go
+++ b/system_tests/eigenda_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
 	"github.com/offchainlabs/nitro/das"
-	"github.com/offchainlabs/nitro/eigenda"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/headerreader"
 )
@@ -159,7 +158,7 @@ func testFailOverFromEigenDAToCallData(t *testing.T) {
 				continue
 			}
 
-			if eigenda.IsEigenDAMessageHeaderByte(serializedBatch[40]) {
+			if daprovider.IsEigenDAMessageHeaderByte(serializedBatch[40]) {
 				eigenDASeen = true
 			} else if daprovider.IsBrotliMessageHeaderByte(serializedBatch[40]) {
 				callDataBatchSeen = true
@@ -336,7 +335,7 @@ func testFailOverFromEigenDAToAnyTrust(t *testing.T) {
 			continue
 		}
 
-		if eigenda.IsEigenDAMessageHeaderByte(serializedBatch[40]) {
+		if daprovider.IsEigenDAMessageHeaderByte(serializedBatch[40]) {
 			eigenDASeen = true
 		} else if daprovider.IsDASMessageHeaderByte(serializedBatch[40]) {
 			anyTrustSeen = true


### PR DESCRIPTION
- updates wasm module root in Dockerfile
- puts EigenDA message representation into `daProvider` package to better conform with existing software design