### PR TITLE
chore: eigenda message check in reader if reader not found in `dapReaders` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ COPY ./scripts/download-machine-eigenda.sh .
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32 0x951009942c00b5bd0abec233174fe33fadf7cd5013d17b042f9b28b3b00b469c
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32.1 0x04a297cdd13254c4c6c26388915d416286daf22f3a20e3ebee10400a3129dd17
-RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0x8da5648e4bcd42306affd60f5fe99c3837da38f11a849bc6bd40b7896974ed09
+RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e
 FROM golang:1.23.1-bookworm AS node-builder
 WORKDIR /workspace
 ARG version=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ COPY ./scripts/download-machine-eigenda.sh .
 RUN ./download-machine.sh consensus-v32 0x184884e1eb9fefdc158f6c8ac912bb183bf3cf83f0090317e0bc4ac5860baa39
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32 0x951009942c00b5bd0abec233174fe33fadf7cd5013d17b042f9b28b3b00b469c
 RUN ./download-machine-eigenda.sh consensus-eigenda-v32.1 0x04a297cdd13254c4c6c26388915d416286daf22f3a20e3ebee10400a3129dd17
-RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0xd5c515b0f4a3450ffc8b4086c1de4c484c5efea878e5491e47bd20fb4649c52e
+RUN ./download-machine-eigenda.sh consensus-eigenda-v32.2 0x8da5648e4bcd42306affd60f5fe99c3837da38f11a849bc6bd40b7896974ed09
 FROM golang:1.23.1-bookworm AS node-builder
 WORKDIR /workspace
 ARG version=""

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -104,6 +104,9 @@ func parseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 		}
 
 		if !foundDA {
+			if daprovider.IsEigenDAMessageHeaderByte(payload[0]) {
+				log.Error("No EigenDA Reader configured, but sequencer message found with EigenDA header")
+			}
 			if daprovider.IsDASMessageHeaderByte(payload[0]) {
 				log.Error("No DAS Reader configured, but sequencer message found with DAS header")
 			} else if daprovider.IsBlobHashesHeaderByte(payload[0]) {


### PR DESCRIPTION
**Consideration:** 
Arbitrum imposes two different behaviors for DA targets when a reader isn't found for a particular message:
- 4844: return an error which causes the execution to fail loudly
- AnyTrust: log an error and close the batch as a noop 

Since EigenDA integration is a pseudo-equivalent feature toggle like AnyTrust (i.e, stateful field in rollup config) then it should also be logged vs bubbling an error. 