### PR TITLE
feat: BoLD Inbox Challenge Test with EigenDA

### DIFF
--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
+	"github.com/offchainlabs/nitro/eigenda"
 	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/staker/bold"
@@ -61,25 +62,36 @@ import (
 	"github.com/offchainlabs/nitro/validator/valnode"
 )
 
-// TODO: https://github.com/Layr-Labs/nitro/issues/66
-// func TestChallengeProtocolBOLDReadInboxChallenge(t *testing.T) {
-// 	testChallengeProtocolBOLD(t)
-// }
+// Optional EigenDABoldBatchOpts toggle/config.
+type EigenDABoldBatchOpts struct {
+	Enable bool
+	RPC    string
+}
 
-// TODO: https://github.com/Layr-Labs/nitro/issues/66
-// func TestChallengeProtocolBOLDStartStepChallenge(t *testing.T) {
-// 	opts := []server_arb.SpawnerOption{
-// 		server_arb.WithWrapper(func(inner server_arb.MachineInterface) server_arb.MachineInterface {
-// 			// This wrapper is applied after the BOLD wrapper, so step 0 is the finished machine.
-// 			// Modifying its hash results in invalid inclusion proofs for the evil validator,
-// 			// so we start modifying hashes at step 1 (the first machine step in the running state).
-// 			return NewIncorrectIntermediateMachine(inner, 1)
-// 		}),
-// 	}
-// 	testChallengeProtocolBOLD(t, opts...)
-// }
+func TestChallengeProtocolBOLDReadEigenDAInboxChallenge(t *testing.T) {
+	testChallengeProtocolBOLD(t, &EigenDABoldBatchOpts{
+		Enable: true,
+		RPC:    "http://127.0.0.1:4242",
+	})
+}
 
-func testChallengeProtocolBOLD(t *testing.T, spawnerOpts ...server_arb.SpawnerOption) {
+func TestChallengeProtocolBOLDReadInboxChallenge(t *testing.T) {
+	testChallengeProtocolBOLD(t, nil)
+}
+
+func TestChallengeProtocolBOLDStartStepChallenge(t *testing.T) {
+	opts := []server_arb.SpawnerOption{
+		server_arb.WithWrapper(func(inner server_arb.MachineInterface) server_arb.MachineInterface {
+			// This wrapper is applied after the BOLD wrapper, so step 0 is the finished machine.
+			// Modifying its hash results in invalid inclusion proofs for the evil validator,
+			// so we start modifying hashes at step 1 (the first machine step in the running state).
+			return NewIncorrectIntermediateMachine(inner, 1)
+		}),
+	}
+	testChallengeProtocolBOLD(t, nil, opts...)
+}
+
+func testChallengeProtocolBOLD(t *testing.T, eigenDAOpt *EigenDABoldBatchOpts, spawnerOpts ...server_arb.SpawnerOption) {
 	goodDir, err := os.MkdirTemp("", "good_*")
 	Require(t, err)
 	evilDir, err := os.MkdirTemp("", "evil_*")
@@ -308,19 +320,19 @@ func testChallengeProtocolBOLD(t *testing.T, spawnerOpts ...server_arb.SpawnerOp
 	totalMessagesPosted := int64(0)
 	numMessagesPerBatch := int64(5)
 	divergeAt := int64(-1)
-	makeBoldBatch(t, l2nodeA, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2nodeA, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt, eigenDAOpt)
 	l2info.Accounts["Owner"].Nonce.Store(0)
-	makeBoldBatch(t, l2nodeB, l2info, l1client, &sequencerTxOpts, evilSeqInboxBinding, evilSeqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2nodeB, l2info, l1client, &sequencerTxOpts, evilSeqInboxBinding, evilSeqInbox, numMessagesPerBatch, divergeAt, eigenDAOpt)
 	totalMessagesPosted += numMessagesPerBatch
 
 	// Next, we post another batch, this time containing more messages.
 	// We diverge at message index 5 within the evil node's batch.
 	l2info.Accounts["Owner"].Nonce.Store(5)
 	numMessagesPerBatch = int64(10)
-	makeBoldBatch(t, l2nodeA, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2nodeA, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt, eigenDAOpt)
 	l2info.Accounts["Owner"].Nonce.Store(5)
 	divergeAt = int64(5)
-	makeBoldBatch(t, l2nodeB, l2info, l1client, &sequencerTxOpts, evilSeqInboxBinding, evilSeqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2nodeB, l2info, l1client, &sequencerTxOpts, evilSeqInboxBinding, evilSeqInbox, numMessagesPerBatch, divergeAt, eigenDAOpt)
 	totalMessagesPosted += numMessagesPerBatch
 
 	bcA, err := l2nodeA.InboxTracker.GetBatchCount()
@@ -539,6 +551,8 @@ func createTestNodeOnL1ForBoldProtocol(
 		chainConfig = chaininfo.ArbitrumDevTestChainConfig()
 	}
 	nodeConfig.BatchPoster.DataPoster.MaxMempoolTransactions = 18
+
+	nodeConfig = nodeConfig.WithEigenDATestConfigParams()
 	fatalErrChan := make(chan error, 10)
 	withoutClientWrapper := false
 	l1info, l1client, l1backend, l1stack, _ = createTestL1BlockChain(t, nil, withoutClientWrapper)
@@ -800,13 +814,14 @@ func create2ndNodeWithConfigForBoldProtocol(
 	l1info.SetContract("EvilUpgradeExecutor", addresses.UpgradeExecutor)
 
 	if nodeConfig == nil {
-		nodeConfig = arbnode.ConfigDefaultL1NonSequencerTest()
+		nodeConfig = arbnode.ConfigDefaultL1NonSequencerTest().WithEigenDATestConfigParams()
 	}
 	nodeConfig.ParentChainReader.OldHeaderTimeout = 10 * time.Minute
 	nodeConfig.BatchPoster.DataPoster.MaxMempoolTransactions = 18
 	if stackConfig == nil {
 		stackConfig = testhelpers.CreateStackConfigForTest(t.TempDir())
 	}
+	nodeConfig = nodeConfig.WithEigenDATestConfigParams()
 	l2stack, err := node.New(stackConfig)
 	Require(t, err)
 
@@ -870,6 +885,7 @@ func create2ndNodeWithConfigForBoldProtocol(
 	return l2client, l2node, assertionChain
 }
 
+// Unified batch maker: origin-bytes by default, EigenDA when enabled.
 func makeBoldBatch(
 	t *testing.T,
 	l2Node *arbnode.Node,
@@ -880,6 +896,7 @@ func makeBoldBatch(
 	seqInboxAddr common.Address,
 	numMessages,
 	divergeAtIndex int64,
+	eigen *EigenDABoldBatchOpts, // nil or {Enable:false} => origin; {Enable:true} => EigenDA
 ) {
 	ctx := context.Background()
 
@@ -898,8 +915,66 @@ func makeBoldBatch(
 
 	seqNum := new(big.Int).Lsh(common.Big1, 256)
 	seqNum.Sub(seqNum, common.Big1)
-	tx, err := seqInbox.AddSequencerL2BatchFromOrigin8f111f3c(sequencer, seqNum, message, big.NewInt(1), common.Address{}, big.NewInt(0), big.NewInt(0))
-	Require(t, err)
+
+	var tx *types.Transaction
+	if eigen != nil && eigen.Enable {
+		eig, err := eigenda.NewEigenDA(&eigenda.EigenDAConfig{
+			Enable: true,
+			Rpc:    eigen.RPC,
+		})
+		Require(t, err)
+
+		certV1, err := eig.Store(ctx, message)
+		Require(t, err)
+
+		// Cast EigenDA V1 certificate → Solidity-compatible structs
+		bh := bridgegen.BatchHeader{
+			BlobHeadersRoot:       certV1.BlobVerificationProof.BatchMetadata.BatchHeader.BlobHeadersRoot,
+			QuorumNumbers:         certV1.BlobVerificationProof.BatchMetadata.BatchHeader.QuorumNumbers,
+			SignedStakeForQuorums: certV1.BlobVerificationProof.BatchMetadata.BatchHeader.SignedStakeForQuorums,
+			ReferenceBlockNumber:  certV1.BlobVerificationProof.BatchMetadata.BatchHeader.ReferenceBlockNumber,
+		}
+		bm := bridgegen.BatchMetadata{
+			BatchHeader:             bh,
+			SignatoryRecordHash:     certV1.BlobVerificationProof.BatchMetadata.SignatoryRecordHash,
+			ConfirmationBlockNumber: certV1.BlobVerificationProof.BatchMetadata.ConfirmationBlockNumber,
+		}
+		bvp := bridgegen.BlobVerificationProof{
+			BatchId:        certV1.BlobVerificationProof.BatchId,
+			BlobIndex:      certV1.BlobVerificationProof.BlobIndex,
+			BatchMetadata:  bm,
+			InclusionProof: certV1.BlobVerificationProof.InclusionProof,
+			QuorumIndices:  certV1.BlobVerificationProof.QuorumIndices,
+		}
+
+		solQps := make([]bridgegen.QuorumBlobParam, len(certV1.BlobHeader.QuorumBlobParams))
+		for i, qp := range certV1.BlobHeader.QuorumBlobParams {
+			solQps[i] = bridgegen.QuorumBlobParam{
+				QuorumNumber:                    qp.QuorumNumber,
+				AdversaryThresholdPercentage:    qp.AdversaryThresholdPercentage,
+				ConfirmationThresholdPercentage: qp.ConfirmationThresholdPercentage,
+				ChunkLength:                     qp.ChunkLength,
+			}
+		}
+		blobHeader := bridgegen.BlobHeader{
+			Commitment: bridgegen.BN254G1Point{
+				X: certV1.BlobHeader.Commitment.X,
+				Y: certV1.BlobHeader.Commitment.Y,
+			},
+			DataLength:       certV1.BlobHeader.DataLength,
+			QuorumBlobParams: solQps,
+		}
+		daCert := bridgegen.ISequencerInboxEigenDACert{
+			BlobVerificationProof: bvp,
+			BlobHeader:            blobHeader,
+		}
+
+		tx, err = seqInbox.AddSequencerL2BatchFromEigenDA(sequencer, seqNum, daCert, common.Address{}, big.NewInt(1), big.NewInt(0), big.NewInt(0))
+		Require(t, err)
+	} else {
+		tx, err = seqInbox.AddSequencerL2BatchFromOrigin8f111f3c(sequencer, seqNum, message, big.NewInt(1), common.Address{}, big.NewInt(0), big.NewInt(0))
+		Require(t, err)
+	}
 	receipt, err := EnsureTxSucceeded(ctx, backend, tx)
 	Require(t, err)
 

--- a/system_tests/bold_challenge_protocol_test.go
+++ b/system_tests/bold_challenge_protocol_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbstate"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
+	"github.com/offchainlabs/nitro/daprovider"
 	"github.com/offchainlabs/nitro/eigenda"
 	"github.com/offchainlabs/nitro/execution/gethexec"
 	"github.com/offchainlabs/nitro/staker"
@@ -64,14 +65,12 @@ import (
 
 // Optional EigenDABoldBatchOpts toggle/config.
 type EigenDABoldBatchOpts struct {
-	Enable bool
-	RPC    string
+	RPC string
 }
 
 func TestChallengeProtocolBOLDReadEigenDAInboxChallenge(t *testing.T) {
 	testChallengeProtocolBOLD(t, &EigenDABoldBatchOpts{
-		Enable: true,
-		RPC:    "http://127.0.0.1:4242",
+		RPC: "http://127.0.0.1:4242",
 	})
 }
 
@@ -128,6 +127,7 @@ func testChallengeProtocolBOLD(t *testing.T, eigenDAOpt *EigenDABoldBatchOpts, s
 		nil,
 		sconf,
 		l2info,
+		eigenDAOpts != nil,
 	)
 	defer requireClose(t, l1stack)
 	defer l2nodeA.StopAndWait()
@@ -150,6 +150,7 @@ func testChallengeProtocolBOLD(t *testing.T, eigenDAOpt *EigenDABoldBatchOpts, s
 		nil,
 		sconf,
 		stakeTokenAddr,
+		eigenDAOpts != nil,
 	)
 	defer l2nodeB.StopAndWait()
 
@@ -171,13 +172,26 @@ func testChallengeProtocolBOLD(t *testing.T, eigenDAOpt *EigenDABoldBatchOpts, s
 	_, valStack := createTestValidationNode(t, ctx, &valCfg)
 	blockValidatorConfig := staker.TestBlockValidatorConfig
 
+	var dapReaders []daprovider.Reader = nil
+	if eigenDAOpt != nil {
+		eigenDAService, err := eigenda.NewEigenDA(
+			&eigenda.EigenDAConfig{
+				Enable: true,
+				Rpc:    eigenDAOpt.RPC,
+			})
+		if err != nil {
+			panic(err)
+		}
+		dapReaders = append(dapReaders, eigenda.NewReaderForEigenDA(eigenDAService))
+	}
+
 	statelessA, err := staker.NewStatelessBlockValidator(
 		l2nodeA.InboxReader,
 		l2nodeA.InboxTracker,
 		l2nodeA.TxStreamer,
 		l2nodeA.ExecutionRecorder,
 		l2nodeA.ArbDB,
-		nil,
+		dapReaders,
 		StaticFetcherFrom(t, &blockValidatorConfig),
 		valStack,
 		valCfg.Wasm.RootPath,
@@ -186,14 +200,13 @@ func testChallengeProtocolBOLD(t *testing.T, eigenDAOpt *EigenDABoldBatchOpts, s
 	err = statelessA.Start(ctx)
 	Require(t, err)
 	_, valStackB := createTestValidationNode(t, ctx, &valCfg, spawnerOpts...)
-
 	statelessB, err := staker.NewStatelessBlockValidator(
 		l2nodeB.InboxReader,
 		l2nodeB.InboxTracker,
 		l2nodeB.TxStreamer,
 		l2nodeB.ExecutionRecorder,
 		l2nodeB.ArbDB,
-		nil,
+		dapReaders,
 		StaticFetcherFrom(t, &blockValidatorConfig),
 		valStackB,
 		valCfg.Wasm.RootPath,
@@ -538,6 +551,7 @@ func createTestNodeOnL1ForBoldProtocol(
 	_ *node.Config,
 	rollupStackConf setup.RollupStackConfig,
 	l2infoIn info,
+	useEigenDA bool,
 ) (
 	l2info info, currentNode *arbnode.Node, l2client *ethclient.Client, l2stack *node.Node,
 	l1info info, l1backend *eth.Ethereum, l1client *ethclient.Client, l1stack *node.Node,
@@ -552,7 +566,9 @@ func createTestNodeOnL1ForBoldProtocol(
 	}
 	nodeConfig.BatchPoster.DataPoster.MaxMempoolTransactions = 18
 
-	nodeConfig = nodeConfig.WithEigenDATestConfigParams()
+	if useEigenDA {
+		nodeConfig = nodeConfig.WithEigenDATestConfigParams()
+	}
 	fatalErrChan := make(chan error, 10)
 	withoutClientWrapper := false
 	l1info, l1client, l1backend, l1stack, _ = createTestL1BlockChain(t, nil, withoutClientWrapper)
@@ -796,6 +812,7 @@ func create2ndNodeWithConfigForBoldProtocol(
 	stackConfig *node.Config,
 	rollupStackConf setup.RollupStackConfig,
 	stakeTokenAddr common.Address,
+	useEigenDA bool,
 ) (*ethclient.Client, *arbnode.Node, *solimpl.AssertionChain) {
 	fatalErrChan := make(chan error, 10)
 	l1rpcClient := l1stack.Attach()
@@ -814,14 +831,16 @@ func create2ndNodeWithConfigForBoldProtocol(
 	l1info.SetContract("EvilUpgradeExecutor", addresses.UpgradeExecutor)
 
 	if nodeConfig == nil {
-		nodeConfig = arbnode.ConfigDefaultL1NonSequencerTest().WithEigenDATestConfigParams()
+		nodeConfig = arbnode.ConfigDefaultL1NonSequencerTest()
 	}
 	nodeConfig.ParentChainReader.OldHeaderTimeout = 10 * time.Minute
 	nodeConfig.BatchPoster.DataPoster.MaxMempoolTransactions = 18
 	if stackConfig == nil {
 		stackConfig = testhelpers.CreateStackConfigForTest(t.TempDir())
 	}
-	nodeConfig = nodeConfig.WithEigenDATestConfigParams()
+	if useEigenDA {
+		nodeConfig = nodeConfig.WithEigenDATestConfigParams()
+	}
 	l2stack, err := node.New(stackConfig)
 	Require(t, err)
 
@@ -896,7 +915,7 @@ func makeBoldBatch(
 	seqInboxAddr common.Address,
 	numMessages,
 	divergeAtIndex int64,
-	eigen *EigenDABoldBatchOpts, // nil or {Enable:false} => origin; {Enable:true} => EigenDA
+	eigenDAOpts *EigenDABoldBatchOpts,
 ) {
 	ctx := context.Background()
 
@@ -917,10 +936,10 @@ func makeBoldBatch(
 	seqNum.Sub(seqNum, common.Big1)
 
 	var tx *types.Transaction
-	if eigen != nil && eigen.Enable {
+	if eigenDAOpts != nil {
 		eig, err := eigenda.NewEigenDA(&eigenda.EigenDAConfig{
 			Enable: true,
-			Rpc:    eigen.RPC,
+			Rpc:    eigenDAOpts.RPC,
 		})
 		Require(t, err)
 

--- a/system_tests/bold_state_provider_test.go
+++ b/system_tests/bold_state_provider_test.go
@@ -72,9 +72,9 @@ func TestChallengeProtocolBOLD_Bisections(t *testing.T) {
 	// Make two batchs. One with 5 messages, and one with 10 messages.
 	numMessagesPerBatch := int64(5)
 	divergeAt := int64(-1) // No divergence.
-	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt, nil)
 	numMessagesPerBatch = int64(10)
-	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt, nil)
 
 	bridgeBinding, err := bridgegen.NewBridge(l1info.GetAddress("Bridge"), l1client)
 	Require(t, err)
@@ -188,8 +188,8 @@ func TestChallengeProtocolBOLD_StateProvider(t *testing.T) {
 	// We will make two batches, with 5 messages in each batch.
 	numMessagesPerBatch := int64(5)
 	divergeAt := int64(-1) // No divergence.
-	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt)
-	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt, nil)
+	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, seqInboxBinding, seqInbox, numMessagesPerBatch, divergeAt, nil)
 
 	bridgeBinding, err := bridgegen.NewBridge(l1info.GetAddress("Bridge"), l1client)
 	Require(t, err)

--- a/system_tests/eigenda_test.go
+++ b/system_tests/eigenda_test.go
@@ -27,7 +27,7 @@ const (
 	proxyURL = "http://127.0.0.1:4242"
 )
 
-func TestEigenDAIntegration(t *testing.T) {
+func TestEigenDAV1Integration(t *testing.T) {
 	// single threaded test execution since conflicts can happen
 	// on proxy memconfig states if ran in parallel.
 	// TODO: https://github.com/Layr-Labs/nitro/issues/73
@@ -41,7 +41,6 @@ func TestEigenDAIntegration(t *testing.T) {
 	// 2 - EigenDA failover to native Arbitrum DA destinations
 	testFailOverFromEigenDAToAnyTrust(t)
 	testFailOverFromEigenDAToCallData(t)
-
 }
 
 func testEigenDAProxyBatchPosting(t *testing.T) {

--- a/system_tests/overflow_assertions_test.go
+++ b/system_tests/overflow_assertions_test.go
@@ -160,11 +160,11 @@ func TestOverflowAssertions(t *testing.T) {
 	totalMessagesPosted := int64(0)
 	numMessagesPerBatch := int64(32)
 	divergeAt := int64(-1)
-	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt, nil)
 	totalMessagesPosted += numMessagesPerBatch
 
 	numMessagesPerBatch = int64(13)
-	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt)
+	makeBoldBatch(t, l2node, l2info, l1client, &sequencerTxOpts, honestSeqInboxBinding, honestSeqInbox, numMessagesPerBatch, divergeAt, nil)
 	totalMessagesPosted += numMessagesPerBatch
 
 	bc, err := l2node.InboxTracker.GetBatchCount()


### PR DESCRIPTION
Since we stupidly modified the Sequencer Inbox with a custom access point and accumulation logic for EigenDA V1 messages - we'll need some assurance of E2E correctness of the BoLD proof system for EigenDA V1 message types to ensure one step proofs successfully resolve when calculating the message hash against the main inbox accumulator. 

I've extended the BoLD testing framework to support batch building / dapReader injection for eigenda via proxy. Currently I've added one new test (i.e, `TestChallengeProtocolBOLDReadEigenDAInboxChallenge`)  given this ensures correctness of the aforementioned logic that we've modified. Extending the other BoLD challenge tests with EigenDA isn't very practical since no additional guarantees would be provided and our fork mgmt would only increase.

The challenge tests pass locally for me (despite CI generated non-debuggable errors atm)

**Closes**
- https://github.com/Layr-Labs/nitro/issues/66 

**Related**
- https://github.com/Layr-Labs/bold/pull/3  - bindings weren't up-to date with BoLD contracts submodule 
 