### PR TITLE
fix: eigenda cfg ingestion via CLI 

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -74,7 +74,7 @@ type Config struct {
 	SeqCoordinator           SeqCoordinatorConfig           `koanf:"seq-coordinator"`
 	DataAvailability         das.DataAvailabilityConfig     `koanf:"data-availability"`
 	DAProvider               daclient.ClientConfig          `koanf:"da-provider" reload:"hot"`
-	EigenDA                  eigenda.EigenDAConfig          `koanf:"eigen-da"`
+	EigenDA                  eigenda.EigenDAConfig          `koanf:"eigen-da" reload:"hot"`
 	SyncMonitor              SyncMonitorConfig              `koanf:"sync-monitor"`
 	Dangerous                DangerousConfig                `koanf:"dangerous"`
 	TransactionStreamer      TransactionStreamerConfig      `koanf:"transaction-streamer" reload:"hot"`

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -118,6 +118,11 @@ func (c *Config) Validate() error {
 	if err := c.Staker.Validate(); err != nil {
 		return err
 	}
+
+	if err := c.EigenDA.Validate(); err != nil {
+		return err
+	}
+
 	if c.TransactionStreamer.TrackBlockMetadataFrom != 0 && !c.BlockMetadataFetcher.Enable {
 		log.Warn("track-block-metadata-from is set but blockMetadata fetcher is not enabled")
 	}
@@ -148,6 +153,7 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet, feedInputEnable bool, feed
 	SeqCoordinatorConfigAddOptions(prefix+".seq-coordinator", f)
 	das.DataAvailabilityConfigAddNodeOptions(prefix+".data-availability", f)
 	daclient.ClientConfigAddOptions(prefix+".da-provider", f)
+	eigenda.EigenDAConfigAddOptions(prefix+".eigen-da", f)
 	SyncMonitorConfigAddOptions(prefix+".sync-monitor", f)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	TransactionStreamerConfigAddOptions(prefix+".transaction-streamer", f)
@@ -170,6 +176,7 @@ var ConfigDefault = Config{
 	SeqCoordinator:           DefaultSeqCoordinatorConfig,
 	DataAvailability:         das.DefaultDataAvailabilityConfig,
 	DAProvider:               daclient.DefaultClientConfig,
+	EigenDA:                  eigenda.DefaultEigenDAConfig,
 	SyncMonitor:              DefaultSyncMonitorConfig,
 	Dangerous:                DefaultDangerousConfig,
 	TransactionStreamer:      DefaultTransactionStreamerConfig,

--- a/eigenda/eigenda.go
+++ b/eigenda/eigenda.go
@@ -3,9 +3,12 @@ package eigenda
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -24,8 +27,28 @@ type EigenDAReader interface {
 }
 
 type EigenDAConfig struct {
-	Enable bool   `koanf:"enable"`
-	Rpc    string `koanf:"rpc"`
+	Enable bool `koanf:"enable"`
+	// ugh why is this called RPC when its a rest endpoint for eigenda-proxy. this should be called something else
+	// but this code will soon be nuked so it's not worth introducing a breaking config change
+	Rpc string `koanf:"rpc"`
+}
+
+func (cfg *EigenDAConfig) Validate() error {
+	if cfg.Enable && strings.TrimSpace(cfg.Rpc) == "" {
+		return fmt.Errorf("EigenDA enabled but `rpc` value set for EigenDA Proxy host")
+	}
+
+	return nil
+}
+
+var DefaultEigenDAConfig = EigenDAConfig{
+	Enable: false,
+	Rpc:    "",
+}
+
+func EigenDAConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".enable", DefaultEigenDAConfig.Enable, "whether or not to activate batch posting and/or message derivation using EigenDA")
+	f.String(prefix+".rpc", DefaultEigenDAConfig.Rpc, "url of EigenDA proxy service used to disperse and fetch batches")
 }
 
 type EigenDA struct {

--- a/eigenda/eigenda.go
+++ b/eigenda/eigenda.go
@@ -30,7 +30,7 @@ type EigenDAConfig struct {
 	Enable bool `koanf:"enable"`
 	// ugh why is this called RPC when its a rest endpoint for eigenda-proxy. this should be called something else
 	// but this code will soon be nuked so it's not worth introducing a breaking config change
-	Rpc string `koanf:"rpc"`
+	Rpc string `koanf:"rpc" reload:"hot"`
 }
 
 func (cfg *EigenDAConfig) Validate() error {


### PR DESCRIPTION
The `EigenDAConfig` type wasn't properly wired into the node dependency injection - meaning that these could only be set via env file and not passed via the CLI. Furthermore I aligned the hot-reloading settings to reflect that of the existing AltDA client config that we'll integrate with for V2:
```
type ClientConfig struct {
	Enable     bool                   `koanf:"enable"`
	WithWriter bool                   `koanf:"with-writer"`
	RPC        rpcclient.ClientConfig `koanf:"rpc" reload:"hot"`
}
```