### PR TITLE
chore: disable execution spec tests

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [legacychallenge, long, challenge, l3challenge, execution-spec-tests]
+        # execution-spec-tests are currently disabled  
+        test-mode: [legacychallenge, long, challenge, l3challenge]
 
     steps:
       - name: Checkout

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -28,7 +28,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # execution-spec-tests are currently disabled  
+        # execution-spec-tests are currently disabled due to version incompatibility between
+        # the EigenDA fork and nitro-devnode. Since EigenDA operates at the DA layer (affecting
+        # batching/derivation) rather than the execution layer, these EL-focused tests are not
+        # critical to validate. See: https://github.com/Layr-Labs/nitro/issues/130
         test-mode: [legacychallenge, long, challenge, l3challenge]
 
     steps:


### PR DESCRIPTION
This PR addresses the disabling of `execution-spec-tests` in the nitro fork, reasons mentioned here in #130 