### PR TITLE
Rebase and merge upstream with v3.8.0-rc.12

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-mode: [legacychallenge, long, challenge, l3challenge, execution-spec-tests]
+        # execution-spec-tests are currently disabled  
+        test-mode: [legacychallenge, long, challenge, l3challenge]
 
     steps:
       - name: Checkout

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -28,7 +28,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # execution-spec-tests are currently disabled  
+        # execution-spec-tests are currently disabled due to version incompatibility between
+        # the EigenDA fork and nitro-devnode. Since EigenDA operates at the DA layer (affecting
+        # batching/derivation) rather than the execution layer, these EL-focused tests are not
+        # critical to validate. See: https://github.com/Layr-Labs/nitro/issues/130
         test-mode: [legacychallenge, long, challenge, l3challenge]
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ all: build build-replay-env test-gen-proofs
 	@touch .make/all
 
 .PHONY: build
-build: $(patsubst %,$(output_root)/bin/%, nitro deploy relay daprovider daserver autonomous-auctioneer bidder-client datool el-proxy mockexternalsigner seq-coordinator-invalidate nitro-val seq-coordinator-manager dbconv genesis-generator)
+build: $(patsubst %,$(output_root)/bin/%, nitro deploy relay daprovider daserver autonomous-auctioneer bidder-client datool blobtool el-proxy mockexternalsigner seq-coordinator-invalidate nitro-val seq-coordinator-manager dbconv genesis-generator)
 	@printf $(done)
 
 .PHONY: build-node-deps
@@ -329,6 +329,9 @@ $(output_root)/bin/el-proxy: $(DEP_PREDICATE) build-node-deps
 
 $(output_root)/bin/datool: $(DEP_PREDICATE) build-node-deps
 	go build $(GOLANG_PARAMS) -o $@ "$(CURDIR)/cmd/datool"
+
+$(output_root)/bin/blobtool: $(DEP_PREDICATE) build-node-deps
+	go build $(GOLANG_PARAMS) -o $@ "$(CURDIR)/cmd/blobtool"
 
 $(output_root)/bin/genesis-generator: $(DEP_PREDICATE) build-node-deps
 	go build $(GOLANG_PARAMS) -o $@ "$(CURDIR)/cmd/genesis-generator"

--- a/arbnode/batch_poster.go
+++ b/arbnode/batch_poster.go
@@ -263,7 +263,7 @@ func BatchPosterConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".parent-chain-eip7623", DefaultBatchPosterConfig.ParentChainEip7623, "if parent chain uses EIP7623 (\"yes\", \"no\", \"auto\")")
 	f.Bool(prefix+".delay-buffer-always-updatable", DefaultBatchPosterConfig.DelayBufferAlwaysUpdatable, "always treat delay buffer as updatable")
 	redislock.AddConfigOptions(prefix+".redis-lock", f)
-	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfig)
+	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfig, dataposter.DataPosterUsageBatchPoster)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultBatchPosterConfig.ParentChainWallet.Pathname)
 	DangerousBatchPosterConfigAddOptions(prefix+".dangerous", f)
 }

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -1407,9 +1407,23 @@ func (c *DataPosterConfig) Validate() error {
 // that flags can be reloaded dynamically.
 type ConfigFetcher func() *DataPosterConfig
 
-func DataPosterConfigAddOptions(prefix string, f *pflag.FlagSet, defaultDataPosterConfig DataPosterConfig) {
+// DataPosterUsageContext indicates what component is using the DataPoster to determine
+// which config options to expose.
+type DataPosterUsageContext int
+
+const (
+	// DataPosterUsageStaker indicates the DataPoster is being used by the staker/validator.
+	// Staker posts small (~250 byte) assertions, so blob options don't make sense.
+	// Blob reading is also not supported with assertions.
+	DataPosterUsageStaker DataPosterUsageContext = iota
+	// DataPosterUsageBatchPoster indicates the DataPoster is being used by the batch poster.
+	// Note: The enable flag (post-4844-blobs) is NOT exposed here because batch poster
+	// controls that at its own configuration level.
+	DataPosterUsageBatchPoster
+)
+
+func DataPosterConfigAddOptions(prefix string, f *pflag.FlagSet, defaultDataPosterConfig DataPosterConfig, usageContext DataPosterUsageContext) {
 	f.DurationSlice(prefix+".replacement-times", defaultDataPosterConfig.ReplacementTimes, "comma-separated list of durations since first posting to attempt a replace-by-fee")
-	f.DurationSlice(prefix+".blob-tx-replacement-times", defaultDataPosterConfig.BlobTxReplacementTimes, "comma-separated list of durations since first posting a blob transaction to attempt a replace-by-fee")
 	f.Bool(prefix+".wait-for-l1-finality", defaultDataPosterConfig.WaitForL1Finality, "only treat a transaction as confirmed after L1 finality has been achieved (recommended)")
 	f.Uint64(prefix+".max-mempool-transactions", defaultDataPosterConfig.MaxMempoolTransactions, "the maximum number of transactions to have queued in the mempool at once (0 = unlimited)")
 	f.Uint64(prefix+".max-mempool-weight", defaultDataPosterConfig.MaxMempoolWeight, "the maximum number of weight (weight = min(1, tx.blobs)) to have queued in the mempool at once (0 = unlimited)")
@@ -1417,16 +1431,12 @@ func DataPosterConfigAddOptions(prefix string, f *pflag.FlagSet, defaultDataPost
 	f.Float64(prefix+".target-price-gwei", defaultDataPosterConfig.TargetPriceGwei, "the target price to use for maximum fee cap calculation")
 	f.Float64(prefix+".urgency-gwei", defaultDataPosterConfig.UrgencyGwei, "the urgency to use for maximum fee cap calculation")
 	f.Float64(prefix+".min-tip-cap-gwei", defaultDataPosterConfig.MinTipCapGwei, "the minimum tip cap to post transactions at")
-	f.Float64(prefix+".min-blob-tx-tip-cap-gwei", defaultDataPosterConfig.MinBlobTxTipCapGwei, "the minimum tip cap to post EIP-4844 blob carrying transactions at")
 	f.Float64(prefix+".max-tip-cap-gwei", defaultDataPosterConfig.MaxTipCapGwei, "the maximum tip cap to post transactions at")
-	f.Float64(prefix+".max-blob-tx-tip-cap-gwei", defaultDataPosterConfig.MaxBlobTxTipCapGwei, "the maximum tip cap to post EIP-4844 blob carrying transactions at")
 	f.Uint64(prefix+".max-fee-bid-multiple-bips", uint64(defaultDataPosterConfig.MaxFeeBidMultipleBips), "the maximum multiple of the current price to bid for a transaction's fees (may be exceeded due to min rbf increase, 0 = unlimited)")
 	f.Uint64(prefix+".nonce-rbf-soft-confs", defaultDataPosterConfig.NonceRbfSoftConfs, "the maximum probable reorg depth, used to determine when a transaction will no longer likely need replaced-by-fee")
 	f.Bool(prefix+".allocate-mempool-balance", defaultDataPosterConfig.AllocateMempoolBalance, "if true, don't put transactions in the mempool that spend a total greater than the batch poster's balance")
 	f.Bool(prefix+".use-db-storage", defaultDataPosterConfig.UseDBStorage, "uses database storage when enabled")
 	f.Bool(prefix+".use-noop-storage", defaultDataPosterConfig.UseNoOpStorage, "uses noop storage, it doesn't store anything")
-	f.Bool(prefix+".post-4844-blobs", defaultDataPosterConfig.Post4844Blobs, "if the parent chain supports 4844 blobs and they're well priced, post EIP-4844 blobs")
-	f.String(prefix+".enable-cell-proofs", defaultDataPosterConfig.EnableCellProofs, "enable cell proofs in blob transactions for Fusaka compatibility. Valid values: \"\" or \"auto\" (auto-detect based on L1 Osaka fork), \"force-enable\", \"force-disable\"")
 	f.Bool(prefix+".legacy-storage-encoding", defaultDataPosterConfig.LegacyStorageEncoding, "encodes items in a legacy way (as it was before dropping generics)")
 	f.String(prefix+".max-fee-cap-formula", defaultDataPosterConfig.MaxFeeCapFormula, "mathematical formula to calculate maximum fee cap gwei the result of which would be float64.\n"+
 		"This expression is expected to be evaluated please refer https://github.com/Knetic/govaluate/blob/master/MANUAL.md to find all available mathematical operators.\n"+
@@ -1438,6 +1448,17 @@ func DataPosterConfigAddOptions(prefix string, f *pflag.FlagSet, defaultDataPost
 	addDangerousOptions(prefix+".dangerous", f)
 	addExternalSignerOptions(prefix+".external-signer", f)
 	f.Bool(prefix+".disable-new-tx", defaultDataPosterConfig.DisableNewTx, "disable posting new transactions, data poster will still keep confirming existing batches")
+
+	includeBlobTuning := usageContext != DataPosterUsageStaker
+	if includeBlobTuning {
+		f.DurationSlice(prefix+".blob-tx-replacement-times", defaultDataPosterConfig.BlobTxReplacementTimes, "comma-separated list of durations since first posting a blob transaction to attempt a replace-by-fee")
+		f.Float64(prefix+".min-blob-tx-tip-cap-gwei", defaultDataPosterConfig.MinBlobTxTipCapGwei, "the minimum tip cap to post EIP-4844 blob carrying transactions at")
+		f.Float64(prefix+".max-blob-tx-tip-cap-gwei", defaultDataPosterConfig.MaxBlobTxTipCapGwei, "the maximum tip cap to post EIP-4844 blob carrying transactions at")
+		f.String(prefix+".enable-cell-proofs", defaultDataPosterConfig.EnableCellProofs, "enable cell proofs in blob transactions for Fusaka compatibility. Valid values: \"\" or \"auto\" (auto-detect based on L1 Osaka fork), \"force-enable\", \"force-disable\"")
+	}
+
+	// We intentionally don't expose an option to configure Post4844Blobs.
+	// Components using DataPoster should set it on DataPoster's config themselves.
 }
 
 func addDangerousOptions(prefix string, f *pflag.FlagSet) {
@@ -1487,6 +1508,11 @@ var DefaultDataPosterConfigForValidator = func() DataPosterConfig {
 	// the validator cannot queue transactions
 	config.MaxMempoolTransactions = 1
 	config.MaxMempoolWeight = 1
+	// Clear blob-related fields since they're not applicable to validator
+	config.BlobTxReplacementTimes = nil
+	config.MinBlobTxTipCapGwei = 0
+	config.MaxBlobTxTipCapGwei = 0
+	config.EnableCellProofs = ""
 	return config
 }()
 

--- a/arbnode/dataposter/data_poster.go
+++ b/arbnode/dataposter/data_poster.go
@@ -1213,7 +1213,10 @@ func (p *DataPoster) Start(ctxIn context.Context) {
 			log.Warn("failed to update tx poster nonce", "err", err)
 		}
 		now := time.Now()
-		nextCheck := now.Add(arbmath.MinInt(p.config().ReplacementTimes[0], p.config().BlobTxReplacementTimes[0]))
+		nextCheck := now.Add(p.config().ReplacementTimes[0])
+		if len(p.config().BlobTxReplacementTimes) > 0 {
+			nextCheck = now.Add(arbmath.MinInt(p.config().ReplacementTimes[0], p.config().BlobTxReplacementTimes[0]))
+		}
 		maxTxsToRbf := p.config().MaxMempoolTransactions
 		if maxTxsToRbf == 0 {
 			maxTxsToRbf = 512
@@ -1399,6 +1402,12 @@ func (c *DataPosterConfig) Validate() error {
 		// Valid values
 	default:
 		return fmt.Errorf("invalid enable-cell-proofs value %q (valid: \"\", \"auto\", \"force-enable\", \"force-disable\")", c.EnableCellProofs)
+	}
+	if len(c.ReplacementTimes) == 0 {
+		return fmt.Errorf("replacement-times must have at least one value")
+	}
+	if c.Post4844Blobs && len(c.BlobTxReplacementTimes) == 0 {
+		return fmt.Errorf("blob-tx-replacement-times must have at least one value when post-4844-blobs is enabled")
 	}
 	return nil
 }

--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1406,14 +1406,6 @@ func (n *Node) Start(ctx context.Context) error {
 			return fmt.Errorf("error initializing feed broadcast server: %w", err)
 		}
 	}
-	if n.InboxTracker != nil && n.BroadcastServer != nil {
-		// Even if the sequencer coordinator will populate this backlog,
-		// we want to make sure it's populated before any clients connect.
-		err = n.InboxTracker.PopulateFeedBacklog(n.BroadcastServer)
-		if err != nil {
-			return fmt.Errorf("error populating feed backlog on startup: %w", err)
-		}
-	}
 	err = n.TxStreamer.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("error starting transaction streamer: %w", err)
@@ -1422,6 +1414,14 @@ func (n *Node) Start(ctx context.Context) error {
 		err = n.InboxReader.Start(ctx)
 		if err != nil {
 			return fmt.Errorf("error starting inbox reader: %w", err)
+		}
+	}
+	if n.InboxTracker != nil && n.BroadcastServer != nil {
+		// Even if the sequencer coordinator will populate this backlog,
+		// we want to make sure it's populated before any clients connect.
+		err = n.InboxTracker.PopulateFeedBacklog(n.BroadcastServer)
+		if err != nil {
+			return fmt.Errorf("error populating feed backlog on startup: %w", err)
 		}
 	}
 	// must init broadcast server before trying to sequence anything

--- a/arbnode/parent/parent.go
+++ b/arbnode/parent/parent.go
@@ -6,7 +6,6 @@ package parent
 
 import (
 	"context"
-	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
@@ -109,7 +108,7 @@ func (p *ParentChain) SupportsCellProofs(ctx context.Context, h *types.Header) (
 	}
 	if pCfg.IsArbitrum() {
 		// Arbitrum does not support blob transactions, so this should not have been called.
-		return false, errors.New("parent chain is Arbitrum and does not support blobs")
+		return false, nil
 	}
 	// arbosVersion 0 because we're checking L1 (not L2 Arbitrum)
 	return pCfg.IsOsaka(pCfg.LondonBlock, header.Time, 0), nil

--- a/bold/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/bold/chain-abstraction/sol-implementation/assertion_chain.go
@@ -25,11 +25,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/offchainlabs/nitro/bold/chain-abstraction"
+	protocol "github.com/offchainlabs/nitro/bold/chain-abstraction"
 	"github.com/offchainlabs/nitro/bold/containers"
 	"github.com/offchainlabs/nitro/bold/containers/option"
 	"github.com/offchainlabs/nitro/bold/containers/threadsafe"
-	"github.com/offchainlabs/nitro/bold/runtime"
+	retry "github.com/offchainlabs/nitro/bold/runtime"
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/mocksgen"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
@@ -45,8 +45,6 @@ var (
 )
 
 var assertionCreatedId common.Hash
-
-var defaultBaseGas = int64(500000)
 
 func init() {
 	rollupAbi, err := rollupgen.RollupCoreMetaData.GetAbi()

--- a/cmd/blobtool/blobtool.go
+++ b/cmd/blobtool/blobtool.go
@@ -1,0 +1,234 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+
+// This is a command line tool for testing beacon/blobs and blob_sidecars endpoints.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+
+	"github.com/offchainlabs/nitro/cmd/util/confighelpers"
+	"github.com/offchainlabs/nitro/util/blobs"
+	"github.com/offchainlabs/nitro/util/headerreader"
+)
+
+func main() {
+	args := os.Args
+	if len(args) < 2 {
+		fmt.Println("Usage: blobtool [fetch] ...")
+		os.Exit(1)
+	}
+
+	var err error
+	switch strings.ToLower(args[1]) {
+	case "fetch":
+		err = fetchBlobs(args[2:])
+	default:
+		err = fmt.Errorf("unknown command '%s', valid commands are: fetch", args[1])
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type FetchConfig struct {
+	BeaconURL         string   `koanf:"beacon-url"`
+	Slot              uint64   `koanf:"slot"`
+	VersionedHashes   []string `koanf:"versioned-hashes"`
+	UseLegacyEndpoint bool     `koanf:"use-legacy-endpoint"`
+	CompareEndpoints  bool     `koanf:"compare-endpoints"`
+}
+
+func parseFetchConfig(args []string) (*FetchConfig, error) {
+	f := flag.NewFlagSet("blobtool fetch", flag.ContinueOnError)
+	f.String("beacon-url", "", "Beacon Chain RPC URL. For example with --beacon-url=http://localhost, an RPC call will be made to http://localhost/eth/v1/beacon/blobs")
+	f.Uint64("slot", 0, "Beacon chain slot number to fetch blobs from")
+	f.StringSlice("versioned-hashes", []string{}, "Comma-separated list of versioned hashes to fetch (optional - fetches all if not provided)")
+	f.Bool("use-legacy-endpoint", false, "Use the legacy blob_sidecars endpoint")
+	f.Bool("compare-endpoints", false, "Fetch using both endpoints and compare results")
+
+	k, err := confighelpers.BeginCommonParse(f, args)
+	if err != nil {
+		return nil, err
+	}
+
+	var config FetchConfig
+	if err := confighelpers.EndCommonParse(k, &config); err != nil {
+		return nil, err
+	}
+
+	if config.BeaconURL == "" {
+		return nil, fmt.Errorf("--beacon-url is required")
+	}
+	if config.Slot == 0 {
+		return nil, fmt.Errorf("--slot is required")
+	}
+
+	return &config, nil
+}
+
+func fetchBlobs(args []string) error {
+	config, err := parseFetchConfig(args)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	versionedHashes := make([]common.Hash, len(config.VersionedHashes))
+	for i, hashStr := range config.VersionedHashes {
+		if !common.IsHexAddress(hashStr) && len(hashStr) != 66 {
+			return fmt.Errorf("invalid versioned hash at index %d: %s", i, hashStr)
+		}
+		versionedHashes[i] = common.HexToHash(hashStr)
+	}
+
+	if config.UseLegacyEndpoint && len(versionedHashes) == 0 {
+		return fmt.Errorf("--versioned-hashes is required when using --use-legacy-endpoint")
+	}
+
+	if config.CompareEndpoints {
+		if len(versionedHashes) == 0 {
+			return fmt.Errorf("--versioned-hashes is required when using --compare-endpoints")
+		}
+		return compareEndpoints(ctx, config, versionedHashes)
+	}
+
+	blobClientConfig := headerreader.BlobClientConfig{
+		BeaconUrl:         config.BeaconURL,
+		UseLegacyEndpoint: config.UseLegacyEndpoint,
+	}
+
+	blobClient, err := headerreader.NewBlobClient(blobClientConfig, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create blob client: %w", err)
+	}
+
+	if err := blobClient.Initialize(ctx); err != nil {
+		return fmt.Errorf("failed to initialize blob client: %w", err)
+	}
+
+	endpointType := "new blobs"
+	if config.UseLegacyEndpoint {
+		endpointType = "legacy blob_sidecars"
+	}
+
+	if len(versionedHashes) > 0 {
+		fmt.Printf("Fetching %d blobs for slot %d using %s endpoint...\n", len(versionedHashes), config.Slot, endpointType)
+	} else {
+		fmt.Printf("Fetching all blobs for slot %d using %s endpoint...\n", config.Slot, endpointType)
+	}
+
+	startTime := time.Now()
+	fetchedBlobs, err := blobClient.GetBlobsBySlot(ctx, config.Slot, versionedHashes)
+	if err != nil {
+		return fmt.Errorf("failed to fetch blobs: %w", err)
+	}
+	duration := time.Since(startTime)
+
+	fmt.Printf("Successfully fetched %d blobs in %v\n", len(fetchedBlobs), duration)
+
+	for i, blob := range fetchedBlobs {
+		_, hashes, err := blobs.ComputeCommitmentsAndHashes([]kzg4844.Blob{blob})
+		if err != nil {
+			return fmt.Errorf("failed to compute commitment for blob %d: %w", i, err)
+		}
+		if len(versionedHashes) > 0 {
+			fmt.Printf("Blob %d: versioned_hash=%s (computed=%s), size=%d bytes\n", i, versionedHashes[i].Hex(), hashes[0].Hex(), len(blob))
+		} else {
+			fmt.Printf("Blob %d: versioned_hash=%s, size=%d bytes\n", i, hashes[0].Hex(), len(blob))
+		}
+	}
+
+	return nil
+}
+
+func compareEndpoints(ctx context.Context, config *FetchConfig, versionedHashes []common.Hash) error {
+	fmt.Println("Comparing legacy blob_sidecars and new blobs endpoints...")
+	fmt.Println()
+
+	legacyConfig := headerreader.BlobClientConfig{
+		BeaconUrl:         config.BeaconURL,
+		UseLegacyEndpoint: true,
+	}
+	legacyClient, err := headerreader.NewBlobClient(legacyConfig, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create legacy blob client: %w", err)
+	}
+	if err := legacyClient.Initialize(ctx); err != nil {
+		return fmt.Errorf("failed to initialize legacy blob client: %w", err)
+	}
+
+	fmt.Println("Fetching with legacy blob_sidecars endpoint...")
+	legacyStart := time.Now()
+	legacyBlobs, err := legacyClient.GetBlobsBySlot(ctx, config.Slot, versionedHashes)
+	legacyDuration := time.Since(legacyStart)
+	if err != nil {
+		return fmt.Errorf("failed to fetch blobs with legacy endpoint: %w", err)
+	}
+	fmt.Printf("✓ Legacy endpoint: fetched %d blobs in %v\n", len(legacyBlobs), legacyDuration)
+	fmt.Println()
+
+	newConfig := headerreader.BlobClientConfig{
+		BeaconUrl:         config.BeaconURL,
+		UseLegacyEndpoint: false,
+	}
+	newClient, err := headerreader.NewBlobClient(newConfig, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create new blob client: %w", err)
+	}
+	if err := newClient.Initialize(ctx); err != nil {
+		return fmt.Errorf("failed to initialize new blob client: %w", err)
+	}
+
+	fmt.Println("Fetching with new blobs endpoint...")
+	newStart := time.Now()
+	newBlobs, err := newClient.GetBlobsBySlot(ctx, config.Slot, versionedHashes)
+	newDuration := time.Since(newStart)
+	if err != nil {
+		return fmt.Errorf("failed to fetch blobs with new endpoint: %w", err)
+	}
+	fmt.Printf("✓ New endpoint: fetched %d blobs in %v\n", len(newBlobs), newDuration)
+	fmt.Println()
+
+	if len(legacyBlobs) != len(newBlobs) {
+		return fmt.Errorf("blob count mismatch: legacy=%d, new=%d", len(legacyBlobs), len(newBlobs))
+	}
+
+	fmt.Println("Comparing blob data...")
+	for i := range legacyBlobs {
+		if legacyBlobs[i] != newBlobs[i] {
+			return fmt.Errorf("blob %d data mismatch", i)
+		}
+		_, hashes, err := blobs.ComputeCommitmentsAndHashes([]kzg4844.Blob{legacyBlobs[i]})
+		if err != nil {
+			return fmt.Errorf("failed to compute hash for blob %d: %w", i, err)
+		}
+		fmt.Printf("  Blob %d: ✓ identical (%s)\n", i, hashes[0].Hex())
+	}
+
+	fmt.Println()
+	fmt.Printf("Performance comparison:\n")
+	fmt.Printf("  Legacy endpoint: %v\n", legacyDuration)
+	fmt.Printf("  New endpoint:    %v\n", newDuration)
+	if newDuration < legacyDuration {
+		improvement := float64(legacyDuration-newDuration) / float64(legacyDuration) * 100
+		fmt.Printf("  New endpoint is %.1f%% faster\n", improvement)
+	} else {
+		slower := float64(newDuration-legacyDuration) / float64(legacyDuration) * 100
+		fmt.Printf("  New endpoint is %.1f%% slower\n", slower)
+	}
+
+	return nil
+}

--- a/cmd/nitro/init.go
+++ b/cmd/nitro/init.go
@@ -621,7 +621,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 				if err := dbutil.UnfinishedConversionCheck(chainData); err != nil {
 					return nil, nil, fmt.Errorf("l2chaindata unfinished database conversion check error: %w", err)
 				}
-				wasmDb, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{Cache: config.Execution.Caching.DatabaseCache, Handles: config.Persistent.Handles, MetricsNamespace: "wasm/", PebbleExtraOptions: persistentConfig.Pebble.ExtraOptions("wasm")})
+				wasmDb, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{Cache: config.Execution.Caching.DatabaseCache, Handles: config.Persistent.Handles, MetricsNamespace: "wasm/", PebbleExtraOptions: persistentConfig.Pebble.ExtraOptions("wasm"), NoFreezer: true})
 				if err != nil {
 					return nil, nil, err
 				}
@@ -703,7 +703,7 @@ func openInitializeChainDb(ctx context.Context, stack *node.Node, config *NodeCo
 	if err != nil {
 		return nil, nil, err
 	}
-	wasmDb, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{Cache: config.Execution.Caching.DatabaseCache, Handles: config.Persistent.Handles, MetricsNamespace: "wasm/", PebbleExtraOptions: persistentConfig.Pebble.ExtraOptions("wasm")})
+	wasmDb, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{Cache: config.Execution.Caching.DatabaseCache, Handles: config.Persistent.Handles, MetricsNamespace: "wasm/", PebbleExtraOptions: persistentConfig.Pebble.ExtraOptions("wasm"), NoFreezer: true})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/nitro/init_test.go
+++ b/cmd/nitro/init_test.go
@@ -537,7 +537,7 @@ func TestPurgeIncompatibleWasmerSerializeVersionEntries(t *testing.T) {
 		t.Fatalf("Failed to create test stack: %v", err)
 	}
 	defer stack.Close()
-	db, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", Cache: NodeConfigDefault.Execution.Caching.DatabaseCache, Handles: NodeConfigDefault.Persistent.Handles})
+	db, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", Cache: NodeConfigDefault.Execution.Caching.DatabaseCache, Handles: NodeConfigDefault.Persistent.Handles, NoFreezer: true})
 	if err != nil {
 		t.Fatalf("Failed to open test db: %v", err)
 	}
@@ -618,7 +618,7 @@ func TestPurgeVersion0WasmStoreEntries(t *testing.T) {
 		t.Fatalf("Failed to create test stack: %v", err)
 	}
 	defer stack.Close()
-	db, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", Cache: NodeConfigDefault.Execution.Caching.DatabaseCache, Handles: NodeConfigDefault.Persistent.Handles})
+	db, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", Cache: NodeConfigDefault.Execution.Caching.DatabaseCache, Handles: NodeConfigDefault.Persistent.Handles, NoFreezer: true})
 	if err != nil {
 		t.Fatalf("Failed to open test db: %v", err)
 	}

--- a/cmd/nitro/nitro.go
+++ b/cmd/nitro/nitro.go
@@ -48,7 +48,7 @@ import (
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbnode/resourcemanager"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/blocks_reexecutor"
+	blocksreexecutor "github.com/offchainlabs/nitro/blocks_reexecutor"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/cmd/conf"
 	"github.com/offchainlabs/nitro/cmd/genericconf"
@@ -61,7 +61,7 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/bridgegen"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
-	"github.com/offchainlabs/nitro/staker/legacy"
+	legacystaker "github.com/offchainlabs/nitro/staker/legacy"
 	"github.com/offchainlabs/nitro/staker/validatorwallet"
 	nitroutil "github.com/offchainlabs/nitro/util"
 	"github.com/offchainlabs/nitro/util/colors"
@@ -453,7 +453,7 @@ func mainImpl() int {
 		return 1
 	}
 
-	arbDb, err := stack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", PebbleExtraOptions: nodeConfig.Persistent.Pebble.ExtraOptions("arbitrumdata")})
+	arbDb, err := stack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", PebbleExtraOptions: nodeConfig.Persistent.Pebble.ExtraOptions("arbitrumdata"), NoFreezer: true})
 	deferFuncs = append(deferFuncs, func() { closeDb(arbDb, "arbDb") })
 	if err != nil {
 		log.Error("failed to open database", "err", err)

--- a/cmd/pruning/pruning.go
+++ b/cmd/pruning/pruning.go
@@ -24,7 +24,7 @@ import (
 	"github.com/offchainlabs/nitro/arbnode"
 	"github.com/offchainlabs/nitro/arbnode/dataposter/storage"
 	"github.com/offchainlabs/nitro/arbutil"
-	"github.com/offchainlabs/nitro/bold/chain-abstraction"
+	protocol "github.com/offchainlabs/nitro/bold/chain-abstraction"
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/cmd/conf"
 	"github.com/offchainlabs/nitro/execution/gethexec"
@@ -32,8 +32,8 @@ import (
 	"github.com/offchainlabs/nitro/solgen/go/rollupgen"
 	"github.com/offchainlabs/nitro/staker"
 	"github.com/offchainlabs/nitro/staker/bold"
-	"github.com/offchainlabs/nitro/staker/legacy"
-	"github.com/offchainlabs/nitro/staker/multi_protocol"
+	legacystaker "github.com/offchainlabs/nitro/staker/legacy"
+	multiprotocolstaker "github.com/offchainlabs/nitro/staker/multi_protocol"
 )
 
 type importantRoots struct {
@@ -93,7 +93,7 @@ func findImportantRoots(ctx context.Context, chainDb ethdb.Database, stack *node
 	if chainConfig == nil {
 		return nil, errors.New("database doesn't have a chain config (was this node initialized?)")
 	}
-	arbDb, err := stack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", ReadOnly: true, PebbleExtraOptions: persistentConfig.Pebble.ExtraOptions("arbitrumdata")})
+	arbDb, err := stack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", ReadOnly: true, PebbleExtraOptions: persistentConfig.Pebble.ExtraOptions("arbitrumdata"), NoFreezer: true})
 	if err != nil {
 		return nil, err
 	}

--- a/staker/legacy/staker.go
+++ b/staker/legacy/staker.go
@@ -236,7 +236,7 @@ func L1ValidatorConfigAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".redis-url", DefaultL1ValidatorConfig.RedisUrl, "redis url for L1 validator")
 	f.Uint64(prefix+".extra-gas", DefaultL1ValidatorConfig.ExtraGas, "use this much more gas than estimation says is necessary to post transactions")
 	f.Uint64(prefix+".log-query-batch-size", DefaultL1ValidatorConfig.LogQueryBatchSize, "range ro query from eth_getLogs")
-	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfigForValidator)
+	dataposter.DataPosterConfigAddOptions(prefix+".data-poster", f, dataposter.DefaultDataPosterConfigForValidator, dataposter.DataPosterUsageStaker)
 	DangerousConfigAddOptions(prefix+".dangerous", f)
 	genericconf.WalletConfigAddOptions(prefix+".parent-chain-wallet", f, DefaultL1ValidatorConfig.ParentChainWallet.Pathname)
 	f.Bool(prefix+".enable-fast-confirmation", DefaultL1ValidatorConfig.EnableFastConfirmation, "enable fast confirmation")

--- a/system_tests/common_test.go
+++ b/system_tests/common_test.go
@@ -1674,11 +1674,11 @@ func createNonL1BlockChainWithStackConfig(
 	chainData, err := stack.OpenDatabaseWithOptions("l2chaindata", node.DatabaseOptions{MetricsNamespace: "l2chaindata/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("l2chaindata")})
 	Require(t, err)
 
-	wasmData, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("wasm")})
+	wasmData, err := stack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("wasm"), NoFreezer: true})
 	Require(t, err)
 
 	chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmData)
-	arbDb, err := stack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("arbitrumdata")})
+	arbDb, err := stack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("arbitrumdata"), NoFreezer: true})
 	Require(t, err)
 
 	initReader := statetransfer.NewMemoryInitDataReader(&info.ArbInitData)
@@ -1770,11 +1770,11 @@ func Create2ndNodeWithConfig(
 
 	chainData, err := chainStack.OpenDatabaseWithOptions("l2chaindata", node.DatabaseOptions{MetricsNamespace: "l2chaindata/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("l2chaindata")})
 	Require(t, err)
-	wasmData, err := chainStack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("wasm")})
+	wasmData, err := chainStack.OpenDatabaseWithOptions("wasm", node.DatabaseOptions{MetricsNamespace: "wasm/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("wasm"), NoFreezer: true})
 	Require(t, err)
 	chainDb := rawdb.WrapDatabaseWithWasm(chainData, wasmData)
 
-	arbDb, err := chainStack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("arbitrumdata")})
+	arbDb, err := chainStack.OpenDatabaseWithOptions("arbitrumdata", node.DatabaseOptions{MetricsNamespace: "arbitrumdata/", PebbleExtraOptions: conf.PersistentConfigDefault.Pebble.ExtraOptions("arbitrumdata"), NoFreezer: true})
 	Require(t, err)
 	initReader := statetransfer.NewMemoryInitDataReader(chainInitData)
 

--- a/system_tests/db_conversion_test.go
+++ b/system_tests/db_conversion_test.go
@@ -61,13 +61,13 @@ func TestDatabaseConversionFlaky(t *testing.T) {
 		conv := dbconv.NewDBConverter(&convConfig)
 		err = conv.Convert(ctx)
 		Require(t, err)
-		// move ancients to the destination directory
-		err = os.Rename(
-			path.Join(instanceDir, fmt.Sprintf("%s_old", dbname), "ancient"),
-			path.Join(instanceDir, dbname, "ancient"),
-		)
-		Require(t, err)
 	}
+	// move l2chaindata ancients to the destination directory
+	err = os.Rename(
+		path.Join(instanceDir, "l2chaindata_old", "ancient"),
+		path.Join(instanceDir, "l2chaindata", "ancient"),
+	)
+	Require(t, err)
 
 	builder.l2StackConfig.DBEngine = "pebble"
 	builder.nodeConfig.ParentChainReader.Enable = false

--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -35,6 +35,7 @@ type BlobClient struct {
 	secondaryBeaconUrl *url.URL
 	httpClient         atomic.Pointer[http.Client]
 	authorization      string
+	useLegacyEndpoint  bool
 
 	// Filled in in Initialize()
 	genesisTime    uint64
@@ -49,6 +50,7 @@ type BlobClientConfig struct {
 	SecondaryBeaconUrl string `koanf:"secondary-beacon-url"`
 	BlobDirectory      string `koanf:"blob-directory"`
 	Authorization      string `koanf:"authorization"`
+	UseLegacyEndpoint  bool   `koanf:"use-legacy-endpoint"`
 }
 
 var DefaultBlobClientConfig = BlobClientConfig{
@@ -56,6 +58,7 @@ var DefaultBlobClientConfig = BlobClientConfig{
 	SecondaryBeaconUrl: "",
 	BlobDirectory:      "",
 	Authorization:      "",
+	UseLegacyEndpoint:  false,
 }
 
 func BlobClientAddOptions(prefix string, f *pflag.FlagSet) {
@@ -63,6 +66,7 @@ func BlobClientAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".secondary-beacon-url", DefaultBlobClientConfig.SecondaryBeaconUrl, "Backup beacon Chain RPC URL to use for fetching blobs (normally on port 3500) when unable to fetch from primary")
 	f.String(prefix+".blob-directory", DefaultBlobClientConfig.BlobDirectory, "Full path of the directory to save fetched blobs")
 	f.String(prefix+".authorization", DefaultBlobClientConfig.Authorization, "Value to send with the HTTP Authorization: header for Beacon REST requests, must include both scheme and scheme parameters")
+	f.Bool(prefix+".use-legacy-endpoint", DefaultBlobClientConfig.UseLegacyEndpoint, "Use the legacy blob_sidecars endpoint instead of the blobs endpoint")
 }
 
 func NewBlobClient(config BlobClientConfig, ec *ethclient.Client) (*BlobClient, error) {
@@ -92,6 +96,7 @@ func NewBlobClient(config BlobClientConfig, ec *ethclient.Client) (*BlobClient, 
 		beaconUrl:          beaconUrl,
 		secondaryBeaconUrl: secondaryBeaconUrl,
 		authorization:      config.Authorization,
+		useLegacyEndpoint:  config.UseLegacyEndpoint,
 		blobDirectory:      config.BlobDirectory,
 	}
 	blobClient.httpClient.Store(&http.Client{})
@@ -102,14 +107,15 @@ type fullResult[T any] struct {
 	Data T `json:"data"`
 }
 
-func beaconRequest[T interface{}](b *BlobClient, ctx context.Context, beaconPath string) (T, error) {
-	// Unfortunately, methods on a struct can't be generic.
-
+func beaconRequest[T interface{}](b *BlobClient, ctx context.Context, beaconPath string, queryParams url.Values) (T, error) {
 	var empty T
 
-	fetchData := func(url url.URL) (*http.Response, error) {
-		url.Path = path.Join(url.Path, beaconPath)
-		req, err := http.NewRequestWithContext(ctx, "GET", url.String(), http.NoBody)
+	fetchData := func(beaconUrl url.URL) (*http.Response, error) {
+		beaconUrl.Path = path.Join(beaconUrl.Path, beaconPath)
+		if queryParams != nil {
+			beaconUrl.RawQuery = queryParams.Encode()
+		}
+		req, err := http.NewRequestWithContext(ctx, "GET", beaconUrl.String(), http.NoBody)
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +177,23 @@ func (b *BlobClient) GetBlobs(ctx context.Context, blockHash common.Hash, versio
 		return nil, errors.New("BlobClient hasn't been initialized")
 	}
 	slot := (header.Time - b.genesisTime) / b.secondsPerSlot
-	blobs, err := b.blobSidecars(ctx, slot, versionedHashes)
+
+	return b.GetBlobsBySlot(ctx, slot, versionedHashes)
+}
+
+// Get blobs for a specific beacon chain slot.
+func (b *BlobClient) GetBlobsBySlot(ctx context.Context, slot uint64, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
+	if b.secondsPerSlot == 0 {
+		return nil, errors.New("BlobClient hasn't been initialized")
+	}
+
+	var blobs []kzg4844.Blob
+	var err error
+	if b.useLegacyEndpoint {
+		blobs, err = b.blobSidecars(ctx, slot, versionedHashes)
+	} else {
+		blobs, err = b.getBlobs(ctx, slot, versionedHashes)
+	}
 	if err != nil {
 		// Creates a new http client to avoid reusing the same transport layer connection in the next request.
 		// This strategy can be useful if there is a network load balancer in front of the beacon chain server.
@@ -179,9 +201,52 @@ func (b *BlobClient) GetBlobs(ctx context.Context, blockHash common.Hash, versio
 		// we can potentially connect to a different, and healthy, beacon chain node in the next request.
 		b.httpClient.Store(&http.Client{})
 
-		return nil, fmt.Errorf("error fetching blobs in %d l1 block: %w", header.Number, err)
+		return nil, fmt.Errorf("error fetching blobs for slot %d: %w", slot, err)
 	}
 	return blobs, nil
+}
+
+func (b *BlobClient) getBlobs(ctx context.Context, slot uint64, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
+	queryParams := url.Values{}
+	for _, hash := range versionedHashes {
+		queryParams.Add("versioned_hashes", hash.Hex())
+	}
+
+	response, err := beaconRequest[[]hexutil.Bytes](b, ctx, fmt.Sprintf("/eth/v1/beacon/blobs/%d", slot), queryParams)
+	if err != nil {
+		// #nosec G115
+		roughAgeOfSlot := uint64(time.Now().Unix()) - (b.genesisTime + slot*b.secondsPerSlot)
+		if roughAgeOfSlot > b.secondsPerSlot*32*4096 {
+			return nil, fmt.Errorf("beacon client in getBlobs got error fetching older blobs in slot: %d, an archive endpoint is required, please refer to https://docs.arbitrum.io/run-arbitrum-node/l1-ethereum-beacon-chain-rpc-providers, err: %w", slot, err)
+		} else {
+			return nil, fmt.Errorf("beacon client in getBlobs got error fetching non-expired blobs in slot: %d, err: %w", slot, err)
+		}
+	}
+
+	if len(versionedHashes) > 0 && len(response) != len(versionedHashes) {
+		return nil, fmt.Errorf("expected %d blobs for slot %d but got %d", len(versionedHashes), slot, len(response))
+	}
+
+	output := make([]kzg4844.Blob, len(response))
+	for i, blobData := range response {
+		if len(blobData) != len(output[i]) {
+			return nil, fmt.Errorf("blob at index %d has incorrect length %d, expected %d", i, len(blobData), len(output[i]))
+		}
+		copy(output[i][:], blobData)
+
+		if len(versionedHashes) > 0 {
+			commitment, err := kzg4844.BlobToCommitment(&output[i])
+			if err != nil {
+				return nil, fmt.Errorf("failed to compute commitment for blob %d: %w", i, err)
+			}
+			computedHash := blobs.CommitmentToVersionedHash(commitment)
+			if computedHash != versionedHashes[i] {
+				return nil, fmt.Errorf("blob %d versioned hash mismatch: expected %s, got %s", i, versionedHashes[i].Hex(), computedHash.Hex())
+			}
+		}
+	}
+
+	return output, nil
 }
 
 type blobResponseItem struct {
@@ -198,7 +263,7 @@ type blobResponseItem struct {
 const trailingCharsOfResponse = 25
 
 func (b *BlobClient) blobSidecars(ctx context.Context, slot uint64, versionedHashes []common.Hash) ([]kzg4844.Blob, error) {
-	rawData, err := beaconRequest[json.RawMessage](b, ctx, fmt.Sprintf("/eth/v1/beacon/blob_sidecars/%d", slot))
+	rawData, err := beaconRequest[json.RawMessage](b, ctx, fmt.Sprintf("/eth/v1/beacon/blob_sidecars/%d", slot), nil)
 	if err != nil || len(rawData) == 0 {
 		// blobs are pruned after 4096 epochs (1 epoch = 32 slots), we determine if the requested slot was to be pruned by a non-archive endpoint
 		// #nosec G115
@@ -307,13 +372,13 @@ type getSpecResponse struct {
 }
 
 func (b *BlobClient) Initialize(ctx context.Context) error {
-	genesis, err := beaconRequest[genesisResponse](b, ctx, "/eth/v1/beacon/genesis")
+	genesis, err := beaconRequest[genesisResponse](b, ctx, "/eth/v1/beacon/genesis", nil)
 	if err != nil {
 		return fmt.Errorf("error calling beacon client to get genesisTime: %w", err)
 	}
 	b.genesisTime = uint64(genesis.GenesisTime)
 
-	spec, err := beaconRequest[getSpecResponse](b, ctx, "/eth/v1/config/spec")
+	spec, err := beaconRequest[getSpecResponse](b, ctx, "/eth/v1/config/spec", nil)
 	if err != nil {
 		return fmt.Errorf("error calling beacon client to get secondsPerSlot: %w", err)
 	}

--- a/util/headerreader/blob_client.go
+++ b/util/headerreader/blob_client.go
@@ -43,14 +43,26 @@ type BlobClient struct {
 
 	// Directory to save the fetched blobs
 	blobDirectory string
+
+	// Dangerous options
+	skipBlobProofVerification bool
+}
+
+type BlobClientDangerousConfig struct {
+	SkipBlobProofVerification bool `koanf:"skip-blob-proof-verification"`
 }
 
 type BlobClientConfig struct {
-	BeaconUrl          string `koanf:"beacon-url"`
-	SecondaryBeaconUrl string `koanf:"secondary-beacon-url"`
-	BlobDirectory      string `koanf:"blob-directory"`
-	Authorization      string `koanf:"authorization"`
-	UseLegacyEndpoint  bool   `koanf:"use-legacy-endpoint"`
+	BeaconUrl          string                    `koanf:"beacon-url"`
+	SecondaryBeaconUrl string                    `koanf:"secondary-beacon-url"`
+	BlobDirectory      string                    `koanf:"blob-directory"`
+	Authorization      string                    `koanf:"authorization"`
+	UseLegacyEndpoint  bool                      `koanf:"use-legacy-endpoint"`
+	Dangerous          BlobClientDangerousConfig `koanf:"dangerous"`
+}
+
+var DefaultDangerousConfig = BlobClientDangerousConfig{
+	SkipBlobProofVerification: false,
 }
 
 var DefaultBlobClientConfig = BlobClientConfig{
@@ -59,6 +71,7 @@ var DefaultBlobClientConfig = BlobClientConfig{
 	BlobDirectory:      "",
 	Authorization:      "",
 	UseLegacyEndpoint:  false,
+	Dangerous:          DefaultDangerousConfig,
 }
 
 func BlobClientAddOptions(prefix string, f *pflag.FlagSet) {
@@ -67,6 +80,11 @@ func BlobClientAddOptions(prefix string, f *pflag.FlagSet) {
 	f.String(prefix+".blob-directory", DefaultBlobClientConfig.BlobDirectory, "Full path of the directory to save fetched blobs")
 	f.String(prefix+".authorization", DefaultBlobClientConfig.Authorization, "Value to send with the HTTP Authorization: header for Beacon REST requests, must include both scheme and scheme parameters")
 	f.Bool(prefix+".use-legacy-endpoint", DefaultBlobClientConfig.UseLegacyEndpoint, "Use the legacy blob_sidecars endpoint instead of the blobs endpoint")
+	BlobClientDangerousAddOptions(prefix+".dangerous", f)
+}
+
+func BlobClientDangerousAddOptions(prefix string, f *pflag.FlagSet) {
+	f.Bool(prefix+".skip-blob-proof-verification", DefaultDangerousConfig.SkipBlobProofVerification, "DANGEROUS! Skips verification of KZG proofs for blobs fetched from the beacon node.")
 }
 
 func NewBlobClient(config BlobClientConfig, ec *ethclient.Client) (*BlobClient, error) {
@@ -92,12 +110,13 @@ func NewBlobClient(config BlobClientConfig, ec *ethclient.Client) (*BlobClient, 
 		}
 	}
 	blobClient := &BlobClient{
-		ec:                 ec,
-		beaconUrl:          beaconUrl,
-		secondaryBeaconUrl: secondaryBeaconUrl,
-		authorization:      config.Authorization,
-		useLegacyEndpoint:  config.UseLegacyEndpoint,
-		blobDirectory:      config.BlobDirectory,
+		ec:                        ec,
+		beaconUrl:                 beaconUrl,
+		secondaryBeaconUrl:        secondaryBeaconUrl,
+		authorization:             config.Authorization,
+		useLegacyEndpoint:         config.UseLegacyEndpoint,
+		blobDirectory:             config.BlobDirectory,
+		skipBlobProofVerification: config.Dangerous.SkipBlobProofVerification,
 	}
 	blobClient.httpClient.Store(&http.Client{})
 	return blobClient, nil
@@ -200,6 +219,8 @@ func (b *BlobClient) GetBlobsBySlot(ctx context.Context, slot uint64, versionedH
 		// So supposing that the error is due to a malfunctioning beacon chain node, by creating a new http client
 		// we can potentially connect to a different, and healthy, beacon chain node in the next request.
 		b.httpClient.Store(&http.Client{})
+
+		b.useLegacyEndpoint = !b.useLegacyEndpoint
 
 		return nil, fmt.Errorf("error fetching blobs for slot %d: %w", slot, err)
 	}
@@ -320,12 +341,14 @@ func (b *BlobClient) blobSidecars(ctx context.Context, slot uint64, versionedHas
 
 		copy(output[outputIdx][:], blobItem.Blob)
 
-		var proof kzg4844.Proof
-		copy(proof[:], blobItem.KzgProof)
+		if !b.skipBlobProofVerification {
+			var proof kzg4844.Proof
+			copy(proof[:], blobItem.KzgProof)
 
-		err = kzg4844.VerifyBlobProof(&output[outputIdx], commitment, proof)
-		if err != nil {
-			return nil, fmt.Errorf("failed to verify blob proof for blob at slot(%d) at index(%d), blob(%s)", slot, blobItem.Index, pretty.FirstFewChars(blobItem.Blob.String()))
+			err = kzg4844.VerifyBlobProof(&output[outputIdx], commitment, proof)
+			if err != nil {
+				return nil, fmt.Errorf("failed to verify blob proof for blob at slot(%d) at index(%d), blob(%s)", slot, blobItem.Index, pretty.FirstFewChars(blobItem.Blob.String()))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Merges upstream Arbitrum Nitro v3.8.0-rc.12 into eigenda branch. Zero conflicts, zero EigenDA code changes.

### Changes

- Fixed out-of-bounds array access and added strict validation requiring BlobTxReplacementTimes when blobs are enabled.
- DataPoster now automatically creates fresh HTTP connections on RPC errors, enabling failover to healthy nodes behind load balancers.
- Added support for new /eth/v1/beacon/blobs/{slot} endpoint with automatic fallback to legacy /blob_sidecars endpoint on errors.
- Freezer no longer opens for wasm and arbitrumdata databases. Only l2chaindata ancients are migrated during DB conversions.
- Stricter gas estimation for BoLD transactions to ensure Fusaka compatibility.

  ---
### Other Changes 

  L3 on Arbitrum: Cell proofs now gracefully disabled instead of erroring
  Node Startup: TransactionStreamer initialization order corrected
  New Tool: blobtool CLI for testing beacon blob endpoints
  Submodule: go-ethereum updated
