### PR TITLE
 Merges upstream v3.8.0 (from v3.8.0-rc.16)

### DIFF
--- a/arbnode/inbox_tracker.go
+++ b/arbnode/inbox_tracker.go
@@ -318,8 +318,7 @@ func (t *InboxTracker) PopulateFeedBacklog(broadcastServer *broadcaster.Broadcas
 		}
 		feedMessages = append(feedMessages, feedMessage)
 	}
-	broadcastServer.BroadcastFeedMessages(feedMessages)
-	return nil
+	return broadcastServer.PopulateFeedBacklog(feedMessages)
 }
 
 func (t *InboxTracker) legacyGetDelayedMessageAndAccumulator(ctx context.Context, seqNum uint64) (*arbostypes.L1IncomingMessage, common.Hash, error) {

--- a/broadcaster/broadcaster.go
+++ b/broadcaster/broadcaster.go
@@ -128,6 +128,14 @@ func (b *Broadcaster) BroadcastFeedMessages(messages []*m.BroadcastFeedMessage) 
 	b.server.Broadcast(bm)
 }
 
+func (s *Broadcaster) PopulateFeedBacklog(messages []*m.BroadcastFeedMessage) error {
+	bm := &m.BroadcastMessage{
+		Version:  1,
+		Messages: messages,
+	}
+	return s.server.PopulateFeedBacklog(bm)
+}
+
 func (b *Broadcaster) Confirm(msgIdx arbutil.MessageIndex) {
 	log.Debug("confirming msgIdx", "msgIdx", msgIdx)
 	b.server.Broadcast(&m.BroadcastMessage{

--- a/cmd/chaininfo/arbitrum_chain_info.json
+++ b/cmd/chaininfo/arbitrum_chain_info.json
@@ -254,7 +254,7 @@
       "bridge": "0x38f918D0E9F1b721EDaA41302E399fa1B79333a9",
       "inbox": "0xaAe29B0366299461418F5324a79Afc425BE5ae21",
       "sequencer-inbox": "0x6c97864CE4bEf387dE0b3310A44230f7E3F1be0D",
-      "rollup": "0xd80810638dbDF9081b72C1B33c65375e807281C8",
+      "rollup": "0x042B2E6C5E99d4c521bd49beeD5E99651D9B0Cf4",
       "validator-utils": "0x1f6860C3cac255fFFa72B7410b1183c3a0D261e0",
       "validator-wallet-creator": "0x894fC71fA0A666352824EC954B401573C861D664",
       "stake-token": "0xefb383126640fe4a760010c6e59c397d2b6c7141",

--- a/daprovider/data_streaming/protocol_test.go
+++ b/daprovider/data_streaming/protocol_test.go
@@ -5,7 +5,6 @@ package data_streaming
 
 import (
 	"context"
-	"errors"
 	"math/rand"
 	"net"
 	"net/http"
@@ -165,23 +164,6 @@ func TestDataStreaming_ProtocolSucceedsEvenWithDelays(t *testing.T) {
 	// 3. Ensure we can still finalize the protocol.
 	time.Sleep(messageCollectionExpiry * 9 / 10)
 	result, err := streamer.finalizeStream(ctx, messageId)
-	testhelpers.RequireImpl(t, err)
-	require.Equal(t, message, ([]byte)(result.Message), "protocol resulted in an incorrect message")
-}
-
-func TestDataStreaming_ClientRetriesWhenThereAreConnectionProblems(t *testing.T) {
-	// Server 'goes offline' for a moment just before reading the second chunk
-	var alreadyWentOffline = false
-	ctx, streamer := prepareTestEnv(t, func(i uint64) error {
-		if i == 1 && !alreadyWentOffline {
-			alreadyWentOffline = true
-			return errors.New("service unavailable")
-		}
-		return nil
-
-	})
-	message, _ := getLongRandomMessage(streamer.chunkSize)
-	result, err := streamer.StreamData(ctx, message, timeout)
 	testhelpers.RequireImpl(t, err)
 	require.Equal(t, message, ([]byte)(result.Message), "protocol resulted in an incorrect message")
 }

--- a/daprovider/data_streaming/sender.go
+++ b/daprovider/data_streaming/sender.go
@@ -19,31 +19,20 @@ import (
 )
 
 const (
-	DefaultHttpBodyLimit    = 5 * 1024 * 1024 // Taken from go-ethereum http.defaultBodyLimit
-	TestHttpBodyLimit       = 1024
-	DefaultBaseRetryDelay   = 2 * time.Second
-	DefaultMaxRetryDelay    = 1 * time.Minute
-	DefaultMaxRetryAttempts = 5
+	DefaultHttpBodyLimit = 5 * 1024 * 1024 // Taken from go-ethereum http.defaultBodyLimit
+	TestHttpBodyLimit    = 1024
 )
 
 // lint:require-exhaustive-initialization
 type DataStreamerConfig struct {
 	MaxStoreChunkBodySize int                     `koanf:"max-store-chunk-body-size"`
 	RpcMethods            DataStreamingRPCMethods `koanf:"rpc-methods"`
-
-	// Retry policy for RPC calls
-	BaseRetryDelay   time.Duration `koanf:"base-retry-delay"`
-	MaxRetryDelay    time.Duration `koanf:"max-retry-delay"`
-	MaxRetryAttempts int           `koanf:"max-retry-attempts"`
 }
 
 func DefaultDataStreamerConfig(rpcMethods DataStreamingRPCMethods) DataStreamerConfig {
 	return DataStreamerConfig{
 		MaxStoreChunkBodySize: DefaultHttpBodyLimit,
 		RpcMethods:            rpcMethods,
-		BaseRetryDelay:        DefaultBaseRetryDelay,
-		MaxRetryDelay:         DefaultMaxRetryDelay,
-		MaxRetryAttempts:      DefaultMaxRetryAttempts,
 	}
 }
 
@@ -51,28 +40,21 @@ func TestDataStreamerConfig(rpcMethods DataStreamingRPCMethods) DataStreamerConf
 	return DataStreamerConfig{
 		MaxStoreChunkBodySize: TestHttpBodyLimit,
 		RpcMethods:            rpcMethods,
-		BaseRetryDelay:        100 * time.Millisecond,
-		MaxRetryDelay:         100 * time.Millisecond,
-		MaxRetryAttempts:      3,
 	}
 }
 
 func DataStreamerConfigAddOptions(prefix string, f *pflag.FlagSet, defaultRpcMethods DataStreamingRPCMethods) {
 	f.Int(prefix+".max-store-chunk-body-size", DefaultHttpBodyLimit, "maximum HTTP body size for chunked store requests")
-	f.Duration(prefix+".base-retry-delay", DefaultBaseRetryDelay, "base delay for retrying failed RPC calls")
-	f.Duration(prefix+".max-retry-delay", DefaultMaxRetryDelay, "maximum delay for retrying failed RPC calls")
-	f.Int(prefix+".max-retry-attempts", DefaultMaxRetryAttempts, "maximum number of attempts for retrying failed RPC calls")
 	DataStreamingRPCMethodsAddOptions(prefix+".rpc-methods", f, defaultRpcMethods)
 }
 
 // DataStreamer allows sending arbitrarily big payloads with JSON RPC. It follows a simple chunk-based protocol.
 // lint:require-exhaustive-initialization
 type DataStreamer[Result any] struct {
-	rpcClient        *rpcclient.RpcClient
-	chunkSize        uint64
-	dataSigner       *PayloadSigner
-	rpcMethods       DataStreamingRPCMethods
-	retryDelayPolicy *expDelayPolicy
+	rpcClient  *rpcclient.RpcClient
+	chunkSize  uint64
+	dataSigner *PayloadSigner
+	rpcMethods DataStreamingRPCMethods
 }
 
 // DataStreamingRPCMethods configuration specifies names of the protocol's RPC methods on the server side.
@@ -104,11 +86,6 @@ func NewDataStreamer[T any](config DataStreamerConfig, dataSigner *PayloadSigner
 		chunkSize:  chunkSize,
 		dataSigner: dataSigner,
 		rpcMethods: config.RpcMethods,
-		retryDelayPolicy: &expDelayPolicy{
-			baseDelay:   config.BaseRetryDelay,
-			maxDelay:    config.MaxRetryDelay,
-			maxAttempts: config.MaxRetryAttempts,
-		},
 	}, nil
 }
 
@@ -144,7 +121,7 @@ func (ds *DataStreamer[Result]) startStream(ctx context.Context, params streamPa
 	}
 
 	var result StartStreamingResult
-	err = ds.call(
+	err = ds.rpcClient.CallContext(
 		ctx,
 		&result,
 		ds.rpcMethods.StartStream,
@@ -172,7 +149,7 @@ func (ds *DataStreamer[Result]) sendChunk(ctx context.Context, messageId Message
 	if err != nil {
 		return err
 	}
-	return ds.call(ctx, nil, ds.rpcMethods.StreamChunk, hexutil.Uint64(messageId), hexutil.Uint64(chunkId), hexutil.Bytes(chunkData), hexutil.Bytes(payloadSignature))
+	return ds.rpcClient.CallContext(ctx, nil, ds.rpcMethods.StreamChunk, hexutil.Uint64(messageId), hexutil.Uint64(chunkId), hexutil.Bytes(chunkData), hexutil.Bytes(payloadSignature))
 }
 
 func (ds *DataStreamer[Result]) finalizeStream(ctx context.Context, messageId MessageId) (result *Result, err error) {
@@ -180,41 +157,8 @@ func (ds *DataStreamer[Result]) finalizeStream(ctx context.Context, messageId Me
 	if err != nil {
 		return nil, err
 	}
-	err = ds.call(ctx, &result, ds.rpcMethods.FinalizeStream, hexutil.Uint64(messageId), hexutil.Bytes(payloadSignature))
+	err = ds.rpcClient.CallContext(ctx, &result, ds.rpcMethods.FinalizeStream, hexutil.Uint64(messageId), hexutil.Bytes(payloadSignature))
 	return
-}
-
-type expDelayPolicy struct {
-	baseDelay, maxDelay time.Duration
-	maxAttempts         int
-}
-
-func (e *expDelayPolicy) NextDelay(attempt int) (time.Duration, bool) {
-	if attempt >= e.maxAttempts {
-		return 0, false
-	}
-	if attempt <= 0 {
-		return time.Duration(0), true
-	}
-
-	delay := e.baseDelay * time.Duration(1<<uint(attempt-1)) // nolint:gosec
-	if delay > e.maxDelay {
-		delay = e.maxDelay
-	}
-	return delay, true
-}
-
-func (ds *DataStreamer[Result]) call(ctx context.Context, result interface{}, method string, args ...interface{}) (err error) {
-	for attempt := 1; ; attempt++ {
-		if err = ds.rpcClient.CallContext(ctx, result, method, args...); err == nil {
-			return nil
-		}
-		delay, proceed := ds.retryDelayPolicy.NextDelay(attempt)
-		if !proceed {
-			return fmt.Errorf("failed after %d attempts: %w", attempt, err)
-		}
-		time.Sleep(delay)
-	}
 }
 
 func (ds *DataStreamer[Result]) sign(bytes []byte, extras ...uint64) ([]byte, error) {

--- a/execution/gethexec/sync_monitor.go
+++ b/execution/gethexec/sync_monitor.go
@@ -278,9 +278,6 @@ func (s *SyncMonitor) SetFinalityData(
 	finalizedFinalityData *arbutil.FinalityData,
 	validatedFinalityData *arbutil.FinalityData,
 ) error {
-	s.exec.createBlocksMutex.Lock()
-	defer s.exec.createBlocksMutex.Unlock()
-
 	finalizedBlockHeader, err := s.getFinalityBlockHeader(
 		s.config.FinalizedBlockWaitForBlockValidator,
 		validatedFinalityData,

--- a/wsbroadcastserver/clientmanager.go
+++ b/wsbroadcastserver/clientmanager.go
@@ -151,6 +151,15 @@ func (cm *ClientManager) Broadcast(bm *m.BroadcastMessage) {
 	cm.broadcastChan <- bm
 }
 
+// populateFeedBacklog adds the given BroadcastMessage to backlog, and also broadcasts it to feed if the ClientManager is started
+func (cm *ClientManager) populateFeedBacklog(bm *m.BroadcastMessage) error {
+	if cm.Started() {
+		cm.Broadcast(bm)
+		return nil
+	}
+	return cm.backlog.Append(bm)
+}
+
 func (cm *ClientManager) doBroadcast(bm *m.BroadcastMessage) ([]*ClientConnection, error) {
 	if err := cm.backlog.Append(bm); err != nil {
 		return nil, err

--- a/wsbroadcastserver/wsbroadcastserver.go
+++ b/wsbroadcastserver/wsbroadcastserver.go
@@ -536,6 +536,10 @@ func (s *WSBroadcastServer) Broadcast(bm *m.BroadcastMessage) {
 	s.clientManager.Broadcast(bm)
 }
 
+func (s *WSBroadcastServer) PopulateFeedBacklog(bm *m.BroadcastMessage) error {
+	return s.clientManager.populateFeedBacklog(bm)
+}
+
 func (s *WSBroadcastServer) ClientCount() int32 {
 	return s.clientManager.ClientCount()
 }


### PR DESCRIPTION
## Key Upstream Changes

- DA Provider Refactor ([#3956](https://github.com/OffchainLabs/nitro/pull/3956), [3957](https://github.com/OffchainLabs/nitro/pull/3957))
- Removed internal AnyTrust RPC server - DA providers now use direct Writer/Reader interfaces
- Removed redundant DataStreamer retry logic (5 attempts) - now relies only on RPC client retries (4 attempts)
- Impact on EigenDA: Faster failover to AnyTrust on errors, cleaner architecture for multi-DA setups

#### Bug Fixes
- Fixed feed backlog population [#3955](https://github.com/OffchainLabs/nitro/pull/3955)
- Removed unnecessary lock in finality data [#3916](https://github.com/OffchainLabs/nitro/pull/3916)
- Updated Sepolia contract addresses [#3917](https://github.com/OffchainLabs/nitro/pull/3917)

### Integration Changes

- Modified: arbnode/node.go - Updated EigenDA integration to work with new DA provider factory pattern while maintaining failover support.
---

Upstream: v3.8.0 (62c0aa730) | Previous: v3.8.0-rc.16